### PR TITLE
Trigger Storybook deploy to GitHub Pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@afixt/apg-react",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@afixt/apg-react",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.23.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afixt/apg-react",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Accessible React components implementing every pattern in the WAI-ARIA Authoring Practices Guide (APG)",
   "keywords": [
     "react",
@@ -21,6 +21,9 @@
     "url": "https://www.karlgroves.com"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/AFixt/apg-react.git"


### PR DESCRIPTION
Adds publishConfig.access=public and v1.1.1 patch. Triggers CI which deploys Storybook to GitHub Pages.