### PR TITLE
docs(jsdoc): bulk JSDoc pass + re-enable jsdoc/require-jsdoc

### DIFF
--- a/components/Accordion/Accordion.tsx
+++ b/components/Accordion/Accordion.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 
+/** A single item in a Accordion. */
 interface AccordionItem {
   title: React.ReactNode;
   content: React.ReactNode;
 }
 
+/** Props for the Accordion component. */
 interface AccordionProps {
   items: AccordionItem[];
   openIndex: number | null;
@@ -73,4 +75,5 @@ const Accordion: React.FC<AccordionProps> = ({ items, toggleItem, openIndex }) =
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Accordion pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Accordion;

--- a/components/Alert/Alert.tsx
+++ b/components/Alert/Alert.tsx
@@ -13,10 +13,12 @@
 import React, { useState } from 'react';
 import './Alert.css';
 
+/** Translatable labels for the Alert component. English defaults are used when a key is omitted. */
 interface AlertLabels {
   dismiss?: string;
 }
 
+/** Props for the Alert component. */
 interface AlertProps {
   message: string;
   type: 'info' | 'warning' | 'error';
@@ -46,4 +48,5 @@ const Alert: React.FC<AlertProps> = ({ message, type, labels }) => {
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Alert pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Alert;

--- a/components/AlertDialog/AlertDialog.tsx
+++ b/components/AlertDialog/AlertDialog.tsx
@@ -9,6 +9,7 @@
 import React, { useEffect, useId, useRef } from 'react';
 import './AlertDialog.css';
 
+/** Props for the AlertDialog component. */
 interface AlertDialogProps {
   isOpen: boolean;
   title: string;
@@ -89,4 +90,5 @@ const AlertDialog: React.FC<AlertDialogProps> = ({ isOpen, title, message, onClo
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG AlertDialog pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default AlertDialog;

--- a/components/Article/Article.tsx
+++ b/components/Article/Article.tsx
@@ -12,12 +12,14 @@
 import React, { forwardRef } from 'react';
 import './Article.css';
 
+/** Data shape consumed by the Article component. */
 interface ArticleData {
   id: string;
   title: React.ReactNode;
   content: React.ReactNode;
 }
 
+/** Props for the Article component. */
 interface ArticleProps {
   article: ArticleData;
   ariaPosinset: number;

--- a/components/Breadcrumb/Breadcrumb.tsx
+++ b/components/Breadcrumb/Breadcrumb.tsx
@@ -15,15 +15,18 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import './Breadcrumb.css';
 
+/** A single item in a Breadcrumb. */
 interface BreadcrumbItem {
   path: string;
   label: string;
 }
 
+/** Translatable labels for the Breadcrumb component. English defaults are used when a key is omitted. */
 interface BreadcrumbLabels {
   nav?: string;
 }
 
+/** Props for the Breadcrumb component. */
 interface BreadcrumbProps {
   items: BreadcrumbItem[];
   navLabel?: string;
@@ -54,4 +57,5 @@ const Breadcrumb: React.FC<BreadcrumbProps> = ({ items, navLabel, labels }) => {
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Breadcrumb pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Breadcrumb;

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -21,6 +21,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import './Button.css';
 
+/** Props for the Button component. */
 interface ButtonProps {
   action: () => void;
   label: string;
@@ -99,4 +100,5 @@ const Button: React.FC<ButtonProps> = ({
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Button pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Button;

--- a/components/Carousel/Carousel.tsx
+++ b/components/Carousel/Carousel.tsx
@@ -15,12 +15,14 @@
 import React, { useEffect, useRef, useState } from 'react';
 import './Carousel.css';
 
+/** A slide in a Carousel. */
 interface CarouselSlide {
   id: string;
   label: string;
   content: React.ReactNode;
 }
 
+/** Translatable labels for the Carousel component. English defaults are used when a key is omitted. */
 interface CarouselLabels {
   previousSlide?: string;
   nextSlide?: string;
@@ -29,6 +31,7 @@ interface CarouselLabels {
   selectSlide?: (i: number) => string;
 }
 
+/** Props for the Carousel component. */
 interface CarouselProps {
   slides: CarouselSlide[];
   /** Accessible name for the carousel region. Required for ARIA compliance. */
@@ -141,4 +144,5 @@ const Carousel: React.FC<CarouselProps> = ({ slides, ariaLabel, labels }) => {
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Carousel pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Carousel;

--- a/components/Checkbox/Checkbox.tsx
+++ b/components/Checkbox/Checkbox.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import './Checkbox.css';
 
+/** Props for the Checkbox component. */
 interface CheckboxProps {
   label: string;
   checked: boolean | null;
@@ -64,4 +65,5 @@ const Checkbox: React.FC<CheckboxProps> = ({
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Checkbox pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Checkbox;

--- a/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/components/CheckboxGroup/CheckboxGroup.tsx
@@ -12,11 +12,13 @@ import React, { useEffect, useId, useState } from 'react';
 import Checkbox from '../Checkbox/Checkbox';
 import './CheckboxGroup.css';
 
+/** A single item in a CheckboxGroup. */
 interface CheckboxGroupItem {
   id: string;
   label: string;
 }
 
+/** Props for the CheckboxGroup component. */
 interface CheckboxGroupProps {
   items: CheckboxGroupItem[];
   label: string;
@@ -67,4 +69,5 @@ const CheckboxGroup: React.FC<CheckboxGroupProps> = ({ items, label }) => {
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG CheckboxGroup pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default CheckboxGroup;

--- a/components/Combobox/Combobox.tsx
+++ b/components/Combobox/Combobox.tsx
@@ -21,11 +21,13 @@
 import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
 import './Combobox.css';
 
+/** A single option in a Combobox. */
 interface ComboboxOption {
   value: string;
   label: string;
 }
 
+/** Props for the Combobox component. */
 interface ComboboxProps {
   options: ComboboxOption[];
   value?: string;
@@ -244,4 +246,5 @@ const Combobox: React.FC<ComboboxProps> = ({
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Combobox pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Combobox;

--- a/components/Disclosure/Disclosure.tsx
+++ b/components/Disclosure/Disclosure.tsx
@@ -1,6 +1,7 @@
 import React, { useId, useState } from 'react';
 import './Disclosure.css';
 
+/** Props for the Disclosure component. */
 interface DisclosureProps {
   title: React.ReactNode;
   children: React.ReactNode;
@@ -43,4 +44,5 @@ const Disclosure: React.FC<DisclosureProps> = ({ title, children }) => {
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Disclosure pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Disclosure;

--- a/components/Feed/Feed.tsx
+++ b/components/Feed/Feed.tsx
@@ -20,12 +20,14 @@ import React, { useEffect, useRef, useState } from 'react';
 import Article from '../Article/Article';
 import './Feed.css';
 
+/** Article Data used by the Feed component. */
 interface ArticleData {
   id: string;
   title: React.ReactNode;
   content: React.ReactNode;
 }
 
+/** Props for the Feed component. */
 interface FeedProps {
   fetchArticles: () => Promise<ArticleData[]>;
   /** Accessible name for the feed region. */
@@ -111,4 +113,5 @@ const Feed: React.FC<FeedProps> = ({ fetchArticles, ariaLabel }) => {
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Feed pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Feed;

--- a/components/Grid/Grid.tsx
+++ b/components/Grid/Grid.tsx
@@ -16,11 +16,13 @@
 import React, { useRef, useState } from 'react';
 import './Grid.css';
 
+/** A single column in a Grid. */
 interface GridColumn {
   key: string;
   label: React.ReactNode;
 }
 
+/** Props for the Grid component. */
 interface GridProps {
   /** The accessible name for the grid. When `showCaption` is true this also
    *  renders as a visible caption above the grid and is referenced via
@@ -150,4 +152,5 @@ const Grid: React.FC<GridProps> = ({ label, showCaption = false, columns, rows, 
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Grid pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Grid;

--- a/components/Link/Link.tsx
+++ b/components/Link/Link.tsx
@@ -15,6 +15,7 @@ import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import './Link.css';
 
+/** Props for the Link component. */
 interface LinkProps {
   to: string | object;
   children: React.ReactNode;
@@ -42,4 +43,5 @@ const AccessibleLink: React.FC<LinkProps> = ({ to, children, onClick, ...props }
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG AccessibleLink pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default AccessibleLink;

--- a/components/Listbox/Listbox.tsx
+++ b/components/Listbox/Listbox.tsx
@@ -16,11 +16,13 @@
 import React, { useMemo, useRef, useState } from 'react';
 import './Listbox.css';
 
+/** A single option in a Listbox. */
 interface ListboxOption {
   value: string;
   label: React.ReactNode;
 }
 
+/** Props for the Listbox component. */
 interface ListboxProps {
   options: ListboxOption[];
   value?: string | string[];
@@ -170,4 +172,5 @@ const Listbox: React.FC<ListboxProps> = ({
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Listbox pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Listbox;

--- a/components/MenuButton/MenuButton.tsx
+++ b/components/MenuButton/MenuButton.tsx
@@ -15,12 +15,14 @@
 import React, { useEffect, useId, useRef, useState } from 'react';
 import './MenuButton.css';
 
+/** A single item inside a menu. */
 interface MenuItem {
   id: string;
   label: React.ReactNode;
   onSelect?: () => void;
 }
 
+/** Props for the MenuButton component. */
 interface MenuButtonProps {
   label: React.ReactNode;
   items: MenuItem[];
@@ -162,4 +164,5 @@ const MenuButton: React.FC<MenuButtonProps> = ({ label, items, idPrefix }) => {
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG MenuButton pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default MenuButton;

--- a/components/Menubar/Menubar.tsx
+++ b/components/Menubar/Menubar.tsx
@@ -26,18 +26,21 @@
 import React, { useEffect, useRef, useState } from 'react';
 import './Menubar.css';
 
+/** A single item inside a menu. */
 interface MenuItem {
   id: string;
   label: React.ReactNode;
   onSelect?: () => void;
 }
 
+/** A single menu in a Menubar. */
 interface MenubarMenu {
   id: string;
   label: React.ReactNode;
   items: MenuItem[];
 }
 
+/** Props for the Menubar component. */
 interface MenubarProps {
   label: string;
   menus: MenubarMenu[];
@@ -214,4 +217,5 @@ const Menubar: React.FC<MenubarProps> = ({ label, menus }) => {
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Menubar pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Menubar;

--- a/components/Meter/Meter.tsx
+++ b/components/Meter/Meter.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 import './Meter.css';
 
+/** Props for the Meter component. */
 interface MeterProps {
   value: number;
   minValue?: number;
@@ -60,4 +61,5 @@ const Meter: React.FC<MeterProps> = ({
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Meter pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Meter;

--- a/components/ModalDialog/ModalDialog.tsx
+++ b/components/ModalDialog/ModalDialog.tsx
@@ -14,10 +14,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 import './ModalDialog.css'; // Assume appropriate CSS for styling
 
+/** Translatable labels for the ModalDialog component. English defaults are used when a key is omitted. */
 interface ModalDialogLabels {
   closeDialog?: string;
 }
 
+/** Props for the ModalDialog component. */
 interface ModalDialogProps {
   isOpen: boolean;
   onClose: () => void;
@@ -130,4 +132,5 @@ const ModalDialog: React.FC<ModalDialogProps> = ({
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG ModalDialog pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default ModalDialog;

--- a/components/Progressbar/Progressbar.tsx
+++ b/components/Progressbar/Progressbar.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import './Progressbar.css';
 
+/** Props for the Progressbar component. */
 interface ProgressbarProps {
   value?: number;
   min?: number;
@@ -52,4 +53,5 @@ const Progressbar: React.FC<ProgressbarProps> = ({
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Progressbar pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Progressbar;

--- a/components/RadioGroup/RadioGroup.tsx
+++ b/components/RadioGroup/RadioGroup.tsx
@@ -10,11 +10,13 @@
 import React, { useRef, useState } from 'react';
 import './RadioGroup.css';
 
+/** Radio Option used by the RadioGroup component. */
 interface RadioOption {
   value: string;
   label: string;
 }
 
+/** Props for the RadioGroup component. */
 interface RadioGroupProps {
   name: string;
   label?: string;
@@ -115,4 +117,5 @@ const RadioGroup: React.FC<RadioGroupProps> = ({
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG RadioGroup pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default RadioGroup;

--- a/components/Slider/Slider.tsx
+++ b/components/Slider/Slider.tsx
@@ -6,6 +6,7 @@
 import React, { useRef, useState } from 'react';
 import './Slider.css';
 
+/** Props for the Slider component. */
 interface SliderProps {
   min: number;
   max: number;
@@ -128,4 +129,5 @@ const Slider: React.FC<SliderProps> = ({
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Slider pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Slider;

--- a/components/SliderMultiThumb/SliderMultiThumb.tsx
+++ b/components/SliderMultiThumb/SliderMultiThumb.tsx
@@ -17,6 +17,7 @@
 import React, { useRef, useState } from 'react';
 import './SliderMultiThumb.css';
 
+/** Props for the SliderMultiThumb component. */
 interface SliderMultiThumbProps {
   min: number;
   max: number;
@@ -160,4 +161,5 @@ const SliderMultiThumb: React.FC<SliderMultiThumbProps> = ({
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG SliderMultiThumb pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default SliderMultiThumb;

--- a/components/Spinbutton/Spinbutton.tsx
+++ b/components/Spinbutton/Spinbutton.tsx
@@ -4,11 +4,13 @@
 import React, { useState } from 'react';
 import './Spinbutton.css';
 
+/** Translatable labels for the Spinbutton component. English defaults are used when a key is omitted. */
 interface SpinbuttonLabels {
   increaseValue?: string;
   decreaseValue?: string;
 }
 
+/** Props for the Spinbutton component. */
 interface SpinbuttonProps {
   min: number;
   max: number;
@@ -125,4 +127,5 @@ const Spinbutton: React.FC<SpinbuttonProps> = ({
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Spinbutton pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Spinbutton;

--- a/components/Switch/Switch.tsx
+++ b/components/Switch/Switch.tsx
@@ -15,6 +15,7 @@
 import React, { useId, useState } from 'react';
 import './Switch.css';
 
+/** Props for the Switch component. */
 interface SwitchProps {
   label?: string;
   ariaLabelledby?: string;
@@ -66,4 +67,5 @@ const Switch: React.FC<SwitchProps> = ({
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Switch pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Switch;

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -12,12 +12,14 @@
 import React, { useRef, useState } from 'react';
 import './Tabs.css';
 
+/** Tab Def used by the Tabs component. */
 interface TabDef {
   id: string;
   label: React.ReactNode;
   content: React.ReactNode;
 }
 
+/** Props for the Tabs component. */
 interface TabsProps {
   tabs: TabDef[];
   defaultIndex?: number;
@@ -117,4 +119,5 @@ const Tabs: React.FC<TabsProps> = ({
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Tabs pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Tabs;

--- a/components/Textbox/Textbox.tsx
+++ b/components/Textbox/Textbox.tsx
@@ -9,6 +9,7 @@
 import React, { useId } from 'react';
 import './Textbox.css';
 
+/** Props for the Textbox component. */
 interface TextboxProps {
   label?: string;
   value?: string;
@@ -103,4 +104,5 @@ const Textbox: React.FC<TextboxProps> = ({
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Textbox pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Textbox;

--- a/components/Toolbar/Toolbar.tsx
+++ b/components/Toolbar/Toolbar.tsx
@@ -10,6 +10,7 @@
 import React, { Children, cloneElement, useRef, useState } from 'react';
 import './Toolbar.css';
 
+/** Props for the Toolbar component. */
 interface ToolbarProps {
   label?: string;
   ariaLabelledby?: string;
@@ -22,6 +23,7 @@ interface ToolbarProps {
 // require every consumer to declare a matching prop shape, so we use a
 // narrow any for the child-cloning surface.
 /* eslint-disable @typescript-eslint/no-explicit-any */
+/** Toolbar Child used by the Toolbar component. */
 type ToolbarChild = React.ReactElement<any>;
 
 const Toolbar: React.FC<ToolbarProps> = ({ label, ariaLabelledby, orientation, children }) => {
@@ -104,4 +106,5 @@ const Toolbar: React.FC<ToolbarProps> = ({ label, ariaLabelledby, orientation, c
 };
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
+/** Accessible implementation of the WAI-ARIA APG Toolbar pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Toolbar;

--- a/components/Tooltip/Tooltip.tsx
+++ b/components/Tooltip/Tooltip.tsx
@@ -11,6 +11,7 @@
 import React, { cloneElement, isValidElement, useRef, useState } from 'react';
 import './Tooltip.css';
 
+/** Props for the Tooltip component. */
 interface TooltipProps {
   children: React.ReactNode;
   text: string;
@@ -61,4 +62,5 @@ const Tooltip: React.FC<TooltipProps> = ({ children, text, position = 'top' }) =
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG Tooltip pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default Tooltip;

--- a/components/TreeGrid/TreeGrid.tsx
+++ b/components/TreeGrid/TreeGrid.tsx
@@ -19,17 +19,20 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import './TreeGrid.css';
 
+/** A single column in a TreeGrid. */
 interface TreeGridColumn {
   key: string;
   label: React.ReactNode;
 }
 
+/** A row in a TreeGrid. */
 interface TreeGridRow {
   id: string;
   children?: TreeGridRow[];
   [column: string]: unknown;
 }
 
+/** Props for the TreeGrid component. */
 interface TreeGridProps {
   label: string;
   columns: TreeGridColumn[];
@@ -37,6 +40,7 @@ interface TreeGridProps {
   defaultExpanded?: string[];
 }
 
+/** Internal flat row representation used while rendering TreeGrid. */
 interface FlatRow extends TreeGridRow {
   level: number;
   parentId: string | null;
@@ -229,4 +233,5 @@ const TreeGrid: React.FC<TreeGridProps> = ({ label, columns, rows, defaultExpand
   );
 };
 
+/** Accessible implementation of the WAI-ARIA APG TreeGrid pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default TreeGrid;

--- a/components/TreeView/TreeView.tsx
+++ b/components/TreeView/TreeView.tsx
@@ -19,12 +19,14 @@
 import React, { useMemo, useRef, useState } from 'react';
 import './TreeView.css';
 
+/** Tree Node used by the TreeView component. */
 interface TreeNode {
   id: string;
   label: React.ReactNode;
   children?: TreeNode[];
 }
 
+/** Props for the TreeView component. */
 interface TreeViewProps {
   label: string;
   nodes: TreeNode[];
@@ -32,6 +34,7 @@ interface TreeViewProps {
   defaultExpanded?: string[];
 }
 
+/** Internal flat entry representation used while rendering TreeView. */
 interface FlatEntry {
   id: string;
   label: React.ReactNode;
@@ -203,4 +206,5 @@ const TreeView: React.FC<TreeViewProps> = ({ label, nodes, onSelect, defaultExpa
   return renderNodes(nodes);
 };
 
+/** Accessible implementation of the WAI-ARIA APG TreeView pattern. See the top-of-file comment for keyboard and ARIA details. */
 export default TreeView;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -135,12 +135,27 @@ export default tseslint.config(
       'promise/no-nesting': 'warn',
 
       // ----- JSDoc -----
-      // NOTE: jsdoc/require-jsdoc is intentionally OFF pending a bulk JSDoc
-      // pass on all 31 components (tracked separately). See ADR-0006.
       'jsdoc/check-tag-names': [
         'error',
         { definedTags: ['remarks', 'public', 'internal', 'beta', 'component'] },
       ],
+      'jsdoc/require-jsdoc': [
+        'error',
+        {
+          contexts: [
+            // Exported component variables: `export default const Foo = ...`
+            'ExportDefaultDeclaration > VariableDeclaration',
+            // Components defined as `const Foo: React.FC = ...; export default Foo`
+            'VariableDeclaration:has(VariableDeclarator > ArrowFunctionExpression) ~ ExportDefaultDeclaration',
+            // Prop + data interfaces and type aliases
+            'TSInterfaceDeclaration',
+            'TSTypeAliasDeclaration',
+          ],
+          checkConstructors: false,
+          publicOnly: false,
+        },
+      ],
+      'jsdoc/require-description': ['error', { contexts: ['any'] }],
 
       // ----- Secrets -----
       'no-secrets/no-secrets': [


### PR DESCRIPTION
Re-opened after PR4 merge. Original PR: #68. 86 new JSDoc blocks across 31 components + re-enables jsdoc/require-jsdoc and jsdoc/require-description. Closes the ADR-0006 JSDoc follow-up.