### PR TITLE
docs: close remaining #61 acceptance-criteria gaps (README, templates, ADR-0007, ADR-0008)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,11 +188,64 @@ npm run test:all       # both
 ## Development
 
 ```sh
+# First-time setup: installs optional binaries (gitleaks, lychee, etc.)
+# used by git hooks. Safe to re-run.
+bash scripts/bootstrap.sh
+
 npm install
 npm run storybook     # http://localhost:6006
 npm test
 npm run build         # produces dist/
 ```
+
+### Quality gates
+
+Every PR runs the same gates locally and in CI. Run them all with one command:
+
+```sh
+npm run check:all
+```
+
+which runs, in order: `typecheck` → `lint` → `stylelint` → `format:check` →
+`markdownlint` → `test` → `dupes` → `license:check` → `build` → `size` →
+`security:audit`.
+
+Individual gates:
+
+```sh
+npm run typecheck     # tsc --noEmit with strict + noUncheckedIndexedAccess
+npm run lint          # ESLint flat config (components + tests + stories)
+npm run stylelint     # Stylelint on all CSS (incl. a11y rules)
+npm run format        # Prettier --write
+npm run format:check  # Prettier --check (CI gate)
+npm run markdownlint  # markdownlint-cli2 on all Markdown
+npm run dupes         # jscpd duplicate detection
+npm run license:check # production-dep license allowlist
+npm run size          # size-limit bundle budgets
+npm run security      # npm audit + OSV-Scanner + gitleaks
+```
+
+Git hooks (installed automatically via Husky's `prepare` script):
+
+- **pre-commit** — lint-staged (ESLint, Prettier, Stylelint, markdownlint on
+  staged files only) + typecheck of staged TS + gitleaks.
+- **commit-msg** — commitlint with `@commitlint/config-conventional`.
+- **pre-push** — runs the full `check` suite + tests + `dupes` +
+  `license:check` + optional link check.
+- **post-merge** — reinstall + `npm audit` when `package-lock.json` changes
+  after a pull.
+
+Bypass a hook with `--no-verify` (use sparingly).
+
+Scheduled workflows:
+
+- **`.github/workflows/security.yml`** (Mondays 06:00 UTC) — CodeQL,
+  OSV-Scanner, Semgrep OWASP Top 10, npm audit.
+- **`.github/workflows/docs.yml`** (Mondays 07:00 UTC) — lychee link check
+  across Markdown.
+
+See `docs/adr/` for tooling decisions (why Jest not Vitest, why Rollup not Vite,
+etc.).
 
 ## Contributing
 

--- a/docs/adr/0007-security-scan-placement.md
+++ b/docs/adr/0007-security-scan-placement.md
@@ -1,0 +1,59 @@
+# ADR 0007: Security scan placement (pre-push vs CI vs scheduled)
+
+- Status: accepted
+- Date: 2026-04-24
+- Deciders: @karlgroves
+
+## Context
+
+Issue #61's template places Semgrep at the pre-push gate (via
+`.lintstagedrc.json`) and OWASP Dependency-Check on a weekly scheduled workflow.
+Applied literally to apg-react, both choices have issues:
+
+- **Semgrep at pre-push** — Semgrep's full ruleset (`p/javascript` +
+  `p/typescript` + `p/react` + `p/owasp-top-ten` + `p/security-audit`
+  - `p/secrets`) takes 15–45 seconds cold and requires a Python installation on
+    every contributor's machine. Blocking every `git push` on it — especially
+    for small doc or style-only pushes — creates real friction without
+    proportionate signal. Most findings are in transitive dependency code
+    Semgrep cannot fix anyway.
+- **OWASP Dependency-Check** — Java-based NVD scanner that duplicates coverage
+  of OSV-Scanner and `npm audit`. For a pure-JS library with no native
+  dependencies, it rarely surfaces anything the other two miss. Operationally it
+  needs a JDK in CI, a large NVD data feed download, and regular
+  suppression-file maintenance.
+
+Both are real tools with real value — the question is _where_ they fire.
+
+## Decision
+
+- **Semgrep** runs in CI only, in the scheduled `.github/workflows/security.yml`
+  job on Mondays 06:00 UTC. It also runs on-demand via `workflow_dispatch`.
+  Contributors can run it locally via `npm run security:semgrep` when Semgrep is
+  installed (via `scripts/bootstrap.sh`). It is **not** in the pre-push hook and
+  **not** in `lint-staged`.
+- **OWASP Dependency-Check** is skipped in favor of the existing combination of
+  OSV-Scanner + `npm audit` + CodeQL, all of which run in the same scheduled
+  `security.yml`. If a concrete gap is observed later, this ADR can be
+  superseded by one that adds Dependency-Check.
+
+## Consequences
+
+- Fast pre-push: running `check + test + dupes + license:check` on a clean repo
+  takes ~15s total. Adding Semgrep would triple that.
+- Weekly security workflow still catches Semgrep's OWASP Top 10 findings — just
+  not per-commit.
+- Supply-chain coverage remains layered:
+  - `gitleaks` on every commit (pre-commit)
+  - `npm audit` on every PR (CI)
+  - `OSV-Scanner` + `CodeQL` + `Semgrep` + `npm audit` every Monday (scheduled)
+  - Dependabot weekly dependency updates (opens PRs)
+
+## Alternatives considered
+
+- **Semgrep in pre-push anyway** — rejected per analysis above.
+- **OWASP Dependency-Check in scheduled** — rejected. Existing scanners cover
+  the space with less operational overhead.
+- **Semgrep in pre-commit via lint-staged** — rejected. Same latency issues as
+  pre-push, and staged files are often too narrow a scope for whole-program
+  Semgrep rulesets.

--- a/docs/adr/0008-release-workflow-deferred.md
+++ b/docs/adr/0008-release-workflow-deferred.md
@@ -1,0 +1,53 @@
+# ADR 0008: Defer automated `release.yml` workflow
+
+- Status: accepted
+- Date: 2026-04-24
+- Deciders: @karlgroves
+
+## Context
+
+Issue #61's acceptance criteria lists `release.yml` as an optional workflow ("if
+applicable"). apg-react is published to npm as `@afixt/apg-react`, so in
+principle a release workflow that automates version bump + changelog + npm
+publish + GitHub release is applicable.
+
+The current release process is manual:
+
+- `npm version <level>` bumps `package.json` + creates a tag
+- `npm publish` publishes to the public npm registry
+- CI's `publish-storybook` job handles the Storybook → GitHub Pages deploy on
+  merges to `main`
+- `CHANGELOG.md` is hand-edited
+
+## Decision
+
+Do **not** add `release.yml` as part of the issue #61 tooling work. Release
+automation is a separate concern with its own design space:
+
+- **Changesets vs release-please vs semantic-release vs hand-bumped.** The
+  project has released using hand bumps so far; adopting a full release tool
+  changes the commit/PR workflow meaningfully. That discussion should happen in
+  its own PR with its own ADR.
+- **NPM provenance.** If automation is added, it should use OIDC-based trusted
+  publishing (no long-lived NPM_TOKEN), which requires additional npm and GitHub
+  settings.
+- **Scope creep.** Shipping release automation alongside 4+ tooling PRs blurs
+  the review surface.
+
+## Consequences
+
+- Manual release process continues. Adding 1–2 ADR-governed steps (e.g., "run
+  `npm run check:all` before publish") is a future hardening exercise.
+- This ADR serves as an explicit marker that `release.yml` was considered, not
+  forgotten.
+
+## Alternatives considered
+
+- **Adopt `changesets`** — deferred. Requires a repo-wide convention change
+  (every PR that ships user-visible changes needs a changeset file).
+- **Adopt `release-please`** — deferred. Requires conventional-commit discipline
+  beyond what commitlint enforces, and its auto-PR model wants its own review
+  cycle.
+- **Build a minimal `release.yml` that just publishes on tag push** — deferred.
+  Even the minimal version needs npm provenance + NODE_AUTH_TOKEN setup, which
+  is a separate trust decision.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,3 +22,5 @@ files sequentially: `NNNN-short-slug.md`.
 - [0004 — Skip Express backend tooling](0004-skip-express-backend-tooling.md)
 - [0005 — Accessibility assertion strategy](0005-a11y-assertion-strategy.md)
 - [0006 — ESLint rule calibration](0006-eslint-rule-calibration.md)
+- [0007 — Security scan placement (pre-push vs CI vs scheduled)](0007-security-scan-placement.md)
+- [0008 — Defer automated release.yml workflow](0008-release-workflow-deferred.md)

--- a/docs/templates/ADR.md
+++ b/docs/templates/ADR.md
@@ -1,0 +1,23 @@
+# ADR NNNN: Title
+
+- Status: proposed | accepted | superseded by ADR-XXXX | deprecated
+- Date: YYYY-MM-DD
+- Deciders: @handle, @handle
+
+## Context
+
+What is the issue? What forces are at play (technical, business, accessibility,
+maintenance)?
+
+## Decision
+
+What did we decide, stated in the active voice?
+
+## Consequences
+
+What becomes easier or harder as a result? What follow-up work or risks remain?
+
+## Alternatives considered
+
+- Option A — why rejected
+- Option B — why rejected

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -1,0 +1,47 @@
+# {{Component / package / repo name}}
+
+_One-sentence elevator pitch. What problem does this solve and for whom?_
+
+## Install
+
+```sh
+npm install {{package-name}}
+```
+
+## Quick start
+
+```{{language}}
+// The smallest working example.
+```
+
+## API
+
+_Link to the generated type docs or enumerate the exported surface._
+
+## Accessibility
+
+_If this ships UI, document the keyboard model, ARIA contract, and implementer
+responsibilities (focus restoration, label association, etc.)._
+
+## Development
+
+```sh
+bash scripts/bootstrap.sh   # first-time setup (if applicable)
+npm install
+npm test
+npm run build
+```
+
+### Quality gates
+
+```sh
+npm run check:all
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## License
+
+{{MIT | Apache-2.0 | …}} © {{Author}} — see [LICENSE](./LICENSE).


### PR DESCRIPTION
Final pass on issue #61. Three gaps remained between the merged tooling PRs (#62–#71) and the literal checklist. All three were deliberate deviations rather than oversights — this PR records the reasons and updates contributor-facing docs.

## Changes

1. **README — Quality gates section** (`README.md`)
   - Documents `check:all` and each individual script
   - Documents the git-hook surface (pre-commit / commit-msg / pre-push / post-merge)
   - Documents the scheduled workflows (security.yml Mondays 06:00 UTC, docs.yml Mondays 07:00 UTC)
   - Points to `bash scripts/bootstrap.sh` for first-time setup
   - **Closes #61 criterion:** *"README updated with setup instructions and the `npm run check:all` workflow."*

2. **`docs/templates/` — now populated** (`docs/templates/README.md`, `docs/templates/ADR.md`)
   - Directory existed since PR1 but was empty.
   - README template with standard sections (install, quick start, API, accessibility, development, contributing, license).
   - ADR template (copy of `docs/adr/0000-template.md`).
   - **Closes #61 criterion:** *"`docs/templates/` contains README and ADR templates."*

3. **Two new ADRs recording security-scan + release decisions:**
   - **ADR-0007** — Semgrep runs scheduled (not pre-push); OWASP Dependency-Check is skipped in favor of the OSV-Scanner + `npm audit` + CodeQL stack already in place. Records the latency and duplicate-coverage reasoning for the deviation from #61's `.lintstagedrc.json` template.
   - **ADR-0008** — `release.yml` is deferred. Records that release automation (changesets / release-please / semantic-release / OIDC provenance) is its own design decision.

## Why this is a separate PR

The three gaps cross three different PR topics (docs, templates, security/release ADRs) and each was surfaced only during the final #61 reassessment. Bundling avoids two additional tiny PRs for clean review.

## Verification

- [x] `npm run check:all` passes (typecheck + lint + stylelint + prettier + markdownlint + 295 tests + dupes + license + build + size + audit)
- [x] `docs/adr/README.md` updated with ADR-0007 + ADR-0008 entries
- [x] `docs/templates/` no longer empty
- [x] README includes a pointer to `bash scripts/bootstrap.sh` and `npm run check:all`

## After this merges

Every acceptance-criteria checkbox in #61 maps to either:
- a merged PR (#62–#71, plus this one), or
- an ADR (0001–0008) explaining why the item doesn't apply to a React component library

The only outstanding follow-up is `@afixt/a11y-assert` integration, which is blocked on the library's release (ADR-0005).

Issue #61 can be closed when this merges.