### PR TITLE
chore(lint): adopt @typescript-eslint/naming-convention rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,6 +70,28 @@ export default tseslint.config(
         { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
       ],
       '@typescript-eslint/no-non-null-assertion': 'warn',
+      '@typescript-eslint/naming-convention': [
+        'error',
+        // Quoted property names (e.g. 'aria-describedby', 'data-*') are exempt.
+        {
+          selector: ['objectLiteralProperty', 'typeProperty'],
+          modifiers: ['requiresQuotes'],
+          format: null,
+        },
+        { selector: 'default', format: ['camelCase'] },
+        // PascalCase for React components; UPPER_CASE for module-level constants.
+        { selector: 'variable', format: ['camelCase', 'UPPER_CASE', 'PascalCase'] },
+        { selector: 'parameter', format: ['camelCase'], leadingUnderscore: 'allow' },
+        {
+          selector: 'memberLike',
+          modifiers: ['private'],
+          format: ['camelCase'],
+          leadingUnderscore: 'require',
+        },
+        { selector: 'typeLike', format: ['PascalCase'] },
+        { selector: 'enumMember', format: ['PascalCase', 'UPPER_CASE'] },
+        { selector: 'import', format: ['camelCase', 'PascalCase'] },
+      ],
 
       // ----- React -----
       'react/jsx-key': ['error', { checkFragmentShorthand: true, warnOnDuplicates: true }],


### PR DESCRIPTION
## Summary

- Adds `@typescript-eslint/naming-convention` to the ESLint config for `components/**/*.{ts,tsx}`, `index.ts`, and `types/**/*.d.ts`.
- Uses the suggested baseline from #89 with two project-fit tweaks:
  - quoted properties (e.g. `'aria-describedby'`) are exempted via the `requiresQuotes` modifier so JSX/object props don't trip the rule;
  - `variable` keeps `PascalCase` (React components are declared as `const Foo: React.FC = ...`).
- No code changes were needed — the existing identifiers are already conformant. Lint runs clean (0 errors).

Closes #89

## Test plan

- [x] `npm run lint` — 0 errors (existing warnings unchanged)
- [x] `npm run format:check` — clean
- [x] `npm test` — 295 tests pass across 32 suites
- [ ] CI passes on the PR