### PR TITLE
feat: document component use cases in usecase-runner DSL (#66)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 # testing
 /coverage
 
+# usecase-runner output
+/reports
+/screenshots
+
 # production
 /build
 /dist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,11 @@ Three layers, all runnable locally:
    tabindex, and label association. Zero external a11y libraries.
 3. **E2E tests** (`e2e/*.e2e.js`) — Puppeteer drives a real Chromium against a
    built Storybook. Separate Jest config at `e2e/jest.config.js`.
+4. **Use cases** (`usecases/<component>/*.uc.yaml`) — one discrete user
+   interaction per file in the DSL of `@afixt/usecase-runner`. Targets each
+   component's Storybook story and is meant to be run via the runner (which
+   generates Playwright specs) rather than Jest. Validate without running:
+   `npx --yes @afixt/usecase-runner validate usecases/`.
 
 Configuration:
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ npm run test:all       # both
   assertion library — no external a11y libraries of any kind.
 - **E2E tests** drive a real Chromium against a built Storybook: accessible-name
   presence, `aria-*` id resolution, ARIA boolean grammar, Tab reachability.
+- **Use cases** (`usecases/`) document every user interaction in the DSL of
+  [`@afixt/usecase-runner`](https://www.npmjs.com/package/@afixt/usecase-runner)
+  so the APG keyboard and ARIA contract for each component can be exercised by
+  automation. See [`usecases/README.md`](./usecases/README.md).
 
 ## Development
 

--- a/components/Accordion/Accordion.stories.jsx
+++ b/components/Accordion/Accordion.stories.jsx
@@ -81,3 +81,8 @@ export const FirstOpen = {
     });
   },
 };
+
+// Render-only variants for use case automation. No play function so the story
+// loads in its initial render state.
+export const DefaultBare = { render: Template, args: { items: sampleItems } };
+export const FirstOpenBare = { render: Template, args: { items: sampleItems, openIndex: 0 } };

--- a/components/AlertDialog/AlertDialog.stories.jsx
+++ b/components/AlertDialog/AlertDialog.stories.jsx
@@ -60,3 +60,21 @@ export const OpenByDefault = {
     });
   },
 };
+
+// Render-only variants for use case automation. No play function so the story
+// loads in its initial render state.
+export const DefaultBare = {
+  render: Template,
+  args: {
+    title: 'Confirm action',
+    message: 'Are you sure you want to continue? This action cannot be undone.',
+  },
+};
+export const OpenByDefaultBare = {
+  render: Template,
+  args: {
+    isOpen: true,
+    title: 'Session expired',
+    message: 'Your session has expired. Please sign in again.',
+  },
+};

--- a/components/AlertDialog/AlertDialog.tsx
+++ b/components/AlertDialog/AlertDialog.tsx
@@ -7,6 +7,7 @@
  * - Initial focus placed on the close button
  */
 import React, { useEffect, useId, useRef } from 'react';
+import { cycleFocusInDialog } from '../_internal/dialog-focus';
 import './AlertDialog.css';
 
 /** Props for the AlertDialog component. */
@@ -24,16 +25,22 @@ const AlertDialog: React.FC<AlertDialogProps> = ({ isOpen, title, message, onClo
   const dialogRef = useRef<HTMLDivElement>(null);
   const closeBtnRef = useRef<HTMLButtonElement>(null);
   const invokingElementRef = useRef<Element | null>(null);
+  // Tracks whether the dialog is in the process of closing so the focus trap
+  // doesn't yank focus back to the dialog while we're restoring it to the
+  // invoking element.
+  const closingRef = useRef(false);
 
   // Save invoking element and set initial focus on open.
   useEffect(() => {
     if (isOpen) {
+      closingRef.current = false;
       invokingElementRef.current = document.activeElement;
       closeBtnRef.current?.focus();
     }
   }, [isOpen]);
 
   const closeAndRestoreFocus = () => {
+    closingRef.current = true;
     const invoker = invokingElementRef.current as HTMLElement | null;
     if (invoker && typeof invoker.focus === 'function') {
       invoker.focus();
@@ -48,16 +55,20 @@ const AlertDialog: React.FC<AlertDialogProps> = ({ isOpen, title, message, onClo
       if (e.key === 'Escape') {
         e.stopPropagation();
         closeAndRestoreFocus();
+      } else if (e.key === 'Tab' && dialogRef.current) {
+        cycleFocusInDialog(dialogRef.current, e);
       }
     };
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [isOpen, onClose]);
 
-  // Focus trap — keep focus inside the dialog.
+  // Focus trap — keep focus inside the dialog. Inactive while closing so we
+  // can hand focus back to the invoking element.
   useEffect(() => {
     if (!isOpen) return;
     const handleFocusTrap = (e: FocusEvent) => {
+      if (closingRef.current) return;
       if (dialogRef.current && !dialogRef.current.contains(e.target as Node)) {
         e.stopPropagation();
         closeBtnRef.current?.focus();

--- a/components/Carousel/Carousel.stories.jsx
+++ b/components/Carousel/Carousel.stories.jsx
@@ -73,3 +73,13 @@ export const Default = {
     ariaLabel: 'Featured content',
   },
 };
+
+// Render-only variant for use case automation. Auto-rotation is off so the
+// initial render is stable across the test run.
+export const DefaultBare = {
+  args: {
+    slides,
+    ariaLabel: 'Featured content',
+    initiallyRotating: false,
+  },
+};

--- a/components/Carousel/Carousel.tsx
+++ b/components/Carousel/Carousel.tsx
@@ -36,10 +36,17 @@ interface CarouselProps {
   slides: CarouselSlide[];
   /** Accessible name for the carousel region. Required for ARIA compliance. */
   ariaLabel: string;
+  /** Whether auto-rotation is on at first render. Defaults to true. */
+  initiallyRotating?: boolean;
   labels?: CarouselLabels;
 }
 
-const Carousel: React.FC<CarouselProps> = ({ slides, ariaLabel, labels }) => {
+const Carousel: React.FC<CarouselProps> = ({
+  slides,
+  ariaLabel,
+  initiallyRotating = true,
+  labels,
+}) => {
   const defaultLabels: CarouselLabels = {
     previousSlide: 'Previous slide',
     nextSlide: 'Next slide',
@@ -49,7 +56,7 @@ const Carousel: React.FC<CarouselProps> = ({ slides, ariaLabel, labels }) => {
   };
   const l = { ...defaultLabels, ...labels };
   const [activeIndex, setActiveIndex] = useState(0);
-  const [isRotating, setIsRotating] = useState(true);
+  const [isRotating, setIsRotating] = useState(initiallyRotating);
   const carouselRef = useRef<HTMLDivElement>(null);
 
   const nextSlide = () => {

--- a/components/Checkbox/Checkbox.stories.jsx
+++ b/components/Checkbox/Checkbox.stories.jsx
@@ -90,3 +90,18 @@ export const TriState = {
     });
   },
 };
+
+// Render-only variants for use case automation. No play function so the story
+// loads in its initial render state.
+export const UncheckedBare = {
+  render: Template,
+  args: { label: 'Subscribe to newsletter', checked: false },
+};
+export const CheckedBare = {
+  render: Template,
+  args: { label: 'I accept the terms', checked: true },
+};
+export const TriStateBare = {
+  render: Template,
+  args: { label: 'Select all', checked: null, isTriState: true },
+};

--- a/components/CheckboxGroup/CheckboxGroup.stories.jsx
+++ b/components/CheckboxGroup/CheckboxGroup.stories.jsx
@@ -41,3 +41,16 @@ export const Default = {
     });
   },
 };
+
+// Render-only variant for use case automation. No play function so the story
+// loads in its initial render state.
+export const DefaultBare = {
+  args: {
+    label: 'Notification preferences',
+    items: [
+      { id: '1', label: 'Email notifications' },
+      { id: '2', label: 'SMS notifications' },
+      { id: '3', label: 'Push notifications' },
+    ],
+  },
+};

--- a/components/Combobox/Combobox.stories.jsx
+++ b/components/Combobox/Combobox.stories.jsx
@@ -84,3 +84,22 @@ export const AutocompleteBoth = {
     });
   },
 };
+
+// Render-only variants for use case automation. No play function so the story
+// loads in its initial render state.
+export const AutocompleteListBare = {
+  render: Template,
+  args: {
+    label: 'Country (filters as you type)',
+    autocomplete: 'list',
+    placeholder: 'Type to search…',
+  },
+};
+export const AutocompleteNoneBare = {
+  render: Template,
+  args: { label: 'Country (choose from list)', autocomplete: 'none' },
+};
+export const AutocompleteBothBare = {
+  render: Template,
+  args: { label: 'Country (inline completion)', autocomplete: 'both' },
+};

--- a/components/Grid/Grid.stories.jsx
+++ b/components/Grid/Grid.stories.jsx
@@ -56,3 +56,14 @@ export const Default = {
     });
   },
 };
+
+// Render-only variant for use case automation. No play function so the story
+// loads in its initial render state.
+export const DefaultBare = {
+  args: {
+    label: 'Notable engineers',
+    showCaption: true,
+    columns,
+    rows,
+  },
+};

--- a/components/Listbox/Listbox.stories.jsx
+++ b/components/Listbox/Listbox.stories.jsx
@@ -79,3 +79,14 @@ export const MultiSelect = {
     });
   },
 };
+
+// Render-only variants for use case automation. No play function so the story
+// loads in its initial render state.
+export const SingleSelectBare = {
+  render: Single,
+  args: { label: 'Pick a fruit', options: fruits },
+};
+export const MultiSelectBare = {
+  render: Multi,
+  args: { label: 'Pick fruits', options: fruits },
+};

--- a/components/ModalDialog/ModalDialog.stories.jsx
+++ b/components/ModalDialog/ModalDialog.stories.jsx
@@ -65,3 +65,21 @@ export const OpenByDefault = {
     });
   },
 };
+
+// Render-only variants for use case automation. No play function so the story
+// loads in its initial render state.
+export const DefaultBare = {
+  render: Template,
+  args: {
+    ariaLabelledby: 'modal-title',
+    ariaDescribedby: 'modal-desc',
+  },
+};
+export const OpenByDefaultBare = {
+  render: Template,
+  args: {
+    isOpen: true,
+    ariaLabelledby: 'modal-title',
+    ariaDescribedby: 'modal-desc',
+  },
+};

--- a/components/ModalDialog/ModalDialog.tsx
+++ b/components/ModalDialog/ModalDialog.tsx
@@ -12,6 +12,7 @@
  * @returns {JSX.Element|null} The rendered ModalDialog component.
  */
 import React, { useEffect, useRef, useState } from 'react';
+import { cycleFocusInDialog } from '../_internal/dialog-focus';
 import './ModalDialog.css'; // Assume appropriate CSS for styling
 
 /** Translatable labels for the ModalDialog component. English defaults are used when a key is omitted. */
@@ -48,10 +49,15 @@ const ModalDialog: React.FC<ModalDialogProps> = ({
   const l = { ...defaultLabels, ...labels };
   const dialogRef = useRef<HTMLDivElement>(null);
   const invokingElementRef = useRef<Element | null>(null);
+  // Tracks whether the dialog is in the process of closing so the focus trap
+  // doesn't yank focus back to the dialog while we're restoring it to the
+  // invoking element.
+  const closingRef = useRef(false);
   const [isAnimatingIn, setIsAnimatingIn] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
+      closingRef.current = false;
       invokingElementRef.current = document.activeElement;
       (initialFocusRef?.current || dialogRef.current)?.focus();
       const id = requestAnimationFrame(() => setIsAnimatingIn(true));
@@ -64,6 +70,7 @@ const ModalDialog: React.FC<ModalDialogProps> = ({
   // Restore focus to the element that opened the dialog, then call onClose.
   // If onClose moves focus somewhere else, that naturally takes precedence.
   const closeAndRestoreFocus = () => {
+    closingRef.current = true;
     const invoker = invokingElementRef.current as HTMLElement | null;
     if (invoker && typeof invoker.focus === 'function') {
       invoker.focus();
@@ -83,6 +90,8 @@ const ModalDialog: React.FC<ModalDialogProps> = ({
       if (e.key === 'Escape') {
         e.stopPropagation();
         closeAndRestoreFocus();
+      } else if (e.key === 'Tab' && dialogRef.current) {
+        cycleFocusInDialog(dialogRef.current, e);
       }
     };
     document.addEventListener('keydown', onDocKeyDown);
@@ -90,6 +99,7 @@ const ModalDialog: React.FC<ModalDialogProps> = ({
   }, [isOpen, onClose]);
 
   const handleFocusTrap = (e: FocusEvent) => {
+    if (closingRef.current) return;
     if (dialogRef.current && !dialogRef.current.contains(e.target as Node)) {
       e.stopPropagation();
       (initialFocusRef?.current || dialogRef.current)?.focus();

--- a/components/RadioGroup/RadioGroup.stories.jsx
+++ b/components/RadioGroup/RadioGroup.stories.jsx
@@ -41,3 +41,13 @@ export const Default = {
     });
   },
 };
+
+// Render-only variant for use case automation. No play function so the story
+// loads in its initial render state.
+export const DefaultBare = {
+  args: {
+    label: 'Preferred contact method',
+    name: 'contact',
+    options,
+  },
+};

--- a/components/Slider/Slider.stories.jsx
+++ b/components/Slider/Slider.stories.jsx
@@ -71,3 +71,32 @@ export const Vertical = {
     });
   },
 };
+
+// Render-only variant for use case automation. No play function so the story
+// loads in its initial render state.
+export const HorizontalBare = {
+  args: {
+    min: 0,
+    max: 100,
+    step: 1,
+    initialValue: 50,
+    ariaLabel: 'Volume',
+  },
+};
+export const VerticalBare = {
+  args: {
+    min: 0,
+    max: 100,
+    step: 5,
+    initialValue: 25,
+    isVertical: true,
+    ariaLabel: 'Volume',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: 200 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/components/SliderMultiThumb/SliderMultiThumb.stories.jsx
+++ b/components/SliderMultiThumb/SliderMultiThumb.stories.jsx
@@ -44,3 +44,17 @@ export const PriceRange = {
     });
   },
 };
+
+// Render-only variant for use case automation. No play function so the story
+// loads in its initial render state.
+export const PriceRangeBare = {
+  args: {
+    min: 0,
+    max: 100,
+    step: 1,
+    initialLow: 20,
+    initialHigh: 80,
+    labelLow: 'Minimum price',
+    labelHigh: 'Maximum price',
+  },
+};

--- a/components/Spinbutton/Spinbutton.stories.jsx
+++ b/components/Spinbutton/Spinbutton.stories.jsx
@@ -63,3 +63,12 @@ export const LargeRange = {
     });
   },
 };
+
+// Render-only variants for use case automation. No play function so the story
+// loads in its initial render state.
+export const DefaultBare = {
+  args: { min: 0, max: 10, step: 1, initialValue: 5, ariaLabel: 'Quantity' },
+};
+export const LargeRangeBare = {
+  args: { min: 0, max: 1000, step: 10, initialValue: 100, ariaLabel: 'Amount' },
+};

--- a/components/Switch/Switch.stories.jsx
+++ b/components/Switch/Switch.stories.jsx
@@ -54,3 +54,12 @@ export const On = {
     });
   },
 };
+
+// Render-only variants for use case automation. No play function so the story
+// loads in its initial render state.
+export const OffBare = {
+  args: { label: 'Enable dark mode', initialChecked: false },
+};
+export const OnBare = {
+  args: { label: 'Enable notifications', initialChecked: true },
+};

--- a/components/Tabs/Tabs.stories.jsx
+++ b/components/Tabs/Tabs.stories.jsx
@@ -69,3 +69,13 @@ export const ManualActivation = {
     });
   },
 };
+
+// Render-only variants for use case automation. No play function so the story
+// loads in its initial render state.
+export const HorizontalBare = { args: { tabs, idPrefix: 'h' } };
+export const VerticalBare = {
+  args: { tabs, orientation: 'vertical', idPrefix: 'v' },
+};
+export const ManualActivationBare = {
+  args: { tabs, activation: 'manual', idPrefix: 'm' },
+};

--- a/components/TreeGrid/TreeGrid.stories.jsx
+++ b/components/TreeGrid/TreeGrid.stories.jsx
@@ -75,3 +75,14 @@ export const Default = {
     });
   },
 };
+
+// Render-only variant for use case automation. No play function so the story
+// loads in its initial render state.
+export const DefaultBare = {
+  args: {
+    label: 'Project files',
+    columns,
+    rows,
+    defaultExpanded: ['src'],
+  },
+};

--- a/components/TreeView/TreeView.stories.jsx
+++ b/components/TreeView/TreeView.stories.jsx
@@ -60,3 +60,9 @@ export const Default = {
     });
   },
 };
+
+// Render-only variant for use case automation. No play function so the story
+// loads in its initial render state.
+export const DefaultBare = {
+  args: { label: 'Project files', nodes, defaultExpanded: ['src'] },
+};

--- a/components/_internal/dialog-focus.ts
+++ b/components/_internal/dialog-focus.ts
@@ -1,0 +1,30 @@
+/**
+ * Cycle keyboard focus among the focusable descendants of a dialog container.
+ *
+ * Why this exists: a `focus`-event-based focus trap can't catch the case
+ * where Tab moves focus to `document.body` (the browser's fallback when no
+ * further focusable element exists after the dialog), because no focus event
+ * fires for that fallback. Handling Tab in `keydown` and explicitly cycling
+ * focus inside the dialog covers that case.
+ */
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export const cycleFocusInDialog = (container: HTMLElement, event: KeyboardEvent): void => {
+  if (event.key !== 'Tab') return;
+  const focusables = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  if (!first || !last) {
+    event.preventDefault();
+    return;
+  }
+  const active = document.activeElement;
+  if (event.shiftKey && active === first) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault();
+    first.focus();
+  }
+};

--- a/usecase-runner.config.yaml
+++ b/usecase-runner.config.yaml
@@ -1,0 +1,11 @@
+browser: chromium
+headed: false
+slow_mo: 0
+timeout: 5000
+
+continue_on_failure: true
+screenshot_on_failure: false
+
+report_formats:
+  - json
+report_dir: ./reports

--- a/usecases/README.md
+++ b/usecases/README.md
@@ -1,0 +1,80 @@
+# Use Cases
+
+Executable accessibility use cases for every component in this library, written
+in the DSL of
+[`@afixt/usecase-runner`](https://www.npmjs.com/package/@afixt/usecase-runner).
+
+Each `.uc.yaml` file documents a single discrete user interaction (e.g., "expand
+a collapsed accordion panel by activating its header") in a human-readable form
+that can be exercised by automation. Element targeting is accessibility-first:
+cases use `getByRole`/`getByLabel`-style locators, so a case that fails because
+an element is missing from the accessibility tree is — by design — an
+accessibility finding.
+
+## Layout
+
+```text
+usecases/
+├── README.md                         (this file)
+└── <component>/                      (one directory per component)
+    ├── <component>-<scenario>.uc.yaml
+    └── ...
+```
+
+One file per discrete scenario, grouped by component directory. Filenames are
+kebab-case and start with the component name so they sort and grep cleanly.
+
+## start_location
+
+Every case targets the component's Storybook story directly:
+
+```text
+http://localhost:6006/iframe.html?id=components-<component>--<story>&viewMode=story
+```
+
+Start Storybook with `npm run storybook` (or build with
+`npm run build-storybook` and serve `storybook-static/` on port 6006) before
+running cases.
+
+## Running
+
+Install the runner and Playwright as dev dependencies (peer requirements of the
+runner):
+
+```bash
+npm install --save-dev @afixt/usecase-runner @playwright/test
+npx playwright install chromium
+```
+
+Validate the DSL without executing:
+
+```bash
+npx usecase-runner validate usecases/
+```
+
+Generate Playwright `.spec.ts` files (e.g., for CI):
+
+```bash
+npx usecase-runner generate usecases/ --outdir tests/generated/
+npx playwright test tests/generated/
+```
+
+Or run a single case directly:
+
+```bash
+npx usecase-runner run usecases/accordion/accordion-expand.uc.yaml --headed
+```
+
+## Conventions
+
+- **One scenario per file.** Each file covers exactly one discrete user
+  interaction so failures are precise.
+- **`locate` → `focus` → act.** Every interactive step is preceded by a `locate`
+  and `focus` for the same element to verify the element is in the accessibility
+  tree and can receive keyboard focus.
+- **Prefer role tokens.** Use `button "Save"`, `field "Email"`, `tab "Settings"`
+  etc., not CSS selectors. Fall back to `id`/`data-*` only when the element
+  legitimately lacks an accessible role or name.
+- **Reuse story state.** Pick the Storybook story that already renders the
+  starting state for each scenario (e.g., `FirstOpen` for the accordion-collapse
+  case) instead of building up state through preliminary steps.

--- a/usecases/accordion/accordion-aria-controls.uc.yaml
+++ b/usecases/accordion/accordion-aria-controls.uc.yaml
@@ -1,0 +1,21 @@
+id: accordion-aria-controls
+title: "Accordion — Each header references its panel via aria-controls"
+type: positive
+description: "Verify the ARIA relationship between header and panel: every accordion header
+  exposes an aria-controls attribute that points to its associated region."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-accordion--default-bare&viewMode=story"
+
+expected_result: "Each header button has aria-controls pointing at the id of the region it
+  toggles."
+
+steps:
+  - locate: button "What is APG-React?"
+  - verify: button "What is APG-React?" attribute "aria-controls" is "panel-0"
+  - locate: button "How do I use it?"
+  - verify: button "How do I use it?" attribute "aria-controls" is "panel-1"
+  - locate: button "Is it accessible?"
+  - verify: button "Is it accessible?" attribute "aria-controls" is "panel-2"

--- a/usecases/accordion/accordion-arrow-down-wraps.uc.yaml
+++ b/usecases/accordion/accordion-arrow-down-wraps.uc.yaml
@@ -1,0 +1,18 @@
+id: accordion-arrow-down-wraps
+title: "Accordion — ArrowDown wraps from the last header back to the first"
+type: positive
+description: "When focus is on the last accordion header, ArrowDown wraps focus back to the
+  first header."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-accordion--default-bare&viewMode=story"
+
+expected_result: "Focus moves from the last header to the first header."
+
+steps:
+  - locate: button "Is it accessible?"
+  - focus: button "Is it accessible?"
+  - keyboard: "ArrowDown"
+  - verify: focus button "What is APG-React?"

--- a/usecases/accordion/accordion-arrow-down.uc.yaml
+++ b/usecases/accordion/accordion-arrow-down.uc.yaml
@@ -1,0 +1,18 @@
+id: accordion-arrow-down
+title: "Accordion — ArrowDown moves focus to the next header"
+type: positive
+description: "When focus is on an accordion header, ArrowDown moves focus to the next
+  header in the group."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-accordion--default-bare&viewMode=story"
+
+expected_result: "Focus moves from the first header to the second header."
+
+steps:
+  - locate: button "What is APG-React?"
+  - focus: button "What is APG-React?"
+  - keyboard: "ArrowDown"
+  - verify: focus button "How do I use it?"

--- a/usecases/accordion/accordion-arrow-up-wraps.uc.yaml
+++ b/usecases/accordion/accordion-arrow-up-wraps.uc.yaml
@@ -1,0 +1,18 @@
+id: accordion-arrow-up-wraps
+title: "Accordion — ArrowUp wraps from the first header to the last"
+type: positive
+description: "When focus is on the first accordion header, ArrowUp wraps focus to the last
+  header."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-accordion--default-bare&viewMode=story"
+
+expected_result: "Focus moves from the first header to the last header."
+
+steps:
+  - locate: button "What is APG-React?"
+  - focus: button "What is APG-React?"
+  - keyboard: "ArrowUp"
+  - verify: focus button "Is it accessible?"

--- a/usecases/accordion/accordion-arrow-up.uc.yaml
+++ b/usecases/accordion/accordion-arrow-up.uc.yaml
@@ -1,0 +1,18 @@
+id: accordion-arrow-up
+title: "Accordion — ArrowUp moves focus to the previous header"
+type: positive
+description: "When focus is on an accordion header, ArrowUp moves focus to the previous
+  header in the group."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-accordion--default-bare&viewMode=story"
+
+expected_result: "Focus moves from the second header to the first header."
+
+steps:
+  - locate: button "How do I use it?"
+  - focus: button "How do I use it?"
+  - keyboard: "ArrowUp"
+  - verify: focus button "What is APG-React?"

--- a/usecases/accordion/accordion-collapse.uc.yaml
+++ b/usecases/accordion/accordion-collapse.uc.yaml
@@ -1,0 +1,20 @@
+id: accordion-collapse
+title: "Accordion — Collapse an expanded panel by activating its header"
+type: positive
+description: "Verify that activating an already-expanded accordion header collapses its
+  associated panel and updates aria-expanded to false."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+  - "The FirstOpen Accordion story is rendered with the first panel expanded"
+
+start_location: "http://localhost:6006/iframe.html?id=components-accordion--first-open-bare&viewMode=story"
+
+expected_result: 'The first panel collapses; its header reports aria-expanded="false".'
+
+steps:
+  - locate: button "What is APG-React?"
+  - verify: button "What is APG-React?" attribute "aria-expanded" is "true"
+  - focus: button "What is APG-React?"
+  - activate: button "What is APG-React?"
+  - verify: button "What is APG-React?" attribute "aria-expanded" is "false"

--- a/usecases/accordion/accordion-end.uc.yaml
+++ b/usecases/accordion/accordion-end.uc.yaml
@@ -1,0 +1,18 @@
+id: accordion-end
+title: "Accordion — End moves focus to the last header"
+type: positive
+description: "When focus is on any accordion header, End moves focus to the last header in
+  the group."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-accordion--default-bare&viewMode=story"
+
+expected_result: "Focus moves from a non-last header to the last header."
+
+steps:
+  - locate: button "What is APG-React?"
+  - focus: button "What is APG-React?"
+  - keyboard: "End"
+  - verify: focus button "Is it accessible?"

--- a/usecases/accordion/accordion-expand.uc.yaml
+++ b/usecases/accordion/accordion-expand.uc.yaml
@@ -1,0 +1,22 @@
+id: accordion-expand
+title: "Accordion — Expand a collapsed panel by activating its header"
+type: positive
+description: "Verify that activating a collapsed accordion header expands its associated
+  panel and updates aria-expanded to true."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+  - "The Default Accordion story is rendered with all panels collapsed"
+
+start_location: "http://localhost:6006/iframe.html?id=components-accordion--default-bare&viewMode=story"
+
+expected_result: 'The first panel is expanded; its header reports aria-expanded="true" and the
+  associated region becomes visible.'
+
+steps:
+  - locate: button "What is APG-React?"
+  - verify: button "What is APG-React?" attribute "aria-expanded" is "false"
+  - focus: button "What is APG-React?"
+  - activate: button "What is APG-React?"
+  - verify: button "What is APG-React?" attribute "aria-expanded" is "true"
+  - verify: visible region "What is APG-React?"

--- a/usecases/accordion/accordion-home.uc.yaml
+++ b/usecases/accordion/accordion-home.uc.yaml
@@ -1,0 +1,18 @@
+id: accordion-home
+title: "Accordion — Home moves focus to the first header"
+type: positive
+description: "When focus is on any accordion header, Home moves focus to the first header
+  in the group."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-accordion--default-bare&viewMode=story"
+
+expected_result: "Focus moves from a non-first header to the first header."
+
+steps:
+  - locate: button "Is it accessible?"
+  - focus: button "Is it accessible?"
+  - keyboard: "Home"
+  - verify: focus button "What is APG-React?"

--- a/usecases/alert/alert-dismiss.uc.yaml
+++ b/usecases/alert/alert-dismiss.uc.yaml
@@ -1,0 +1,18 @@
+id: alert-dismiss
+title: "Alert — Activating the Dismiss button removes the alert"
+type: positive
+description: "A user can dismiss the alert by activating its close button. After activation
+  the alert is removed from the accessibility tree."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-alert--info&viewMode=story"
+
+expected_result: "After activating the Dismiss button the alert is no longer present."
+
+steps:
+  - locate: button "Dismiss"
+  - focus: button "Dismiss"
+  - activate: button "Dismiss"
+  - verify: hidden text "This is an informational message."

--- a/usecases/alert/alert-role.uc.yaml
+++ b/usecases/alert/alert-role.uc.yaml
@@ -1,0 +1,16 @@
+id: alert-role
+title: 'Alert — Exposes role="alert" with aria-live="assertive"'
+type: positive
+description: "The Alert component is exposed to assistive technology as a live region that
+  is announced immediately."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-alert--info&viewMode=story"
+
+expected_result: 'The alert message is exposed via role="alert" with aria-live="assertive".'
+
+steps:
+  - locate: text "This is an informational message."
+  - verify: alert "This is an informational message."

--- a/usecases/alertdialog/alertdialog-close-button.uc.yaml
+++ b/usecases/alertdialog/alertdialog-close-button.uc.yaml
@@ -1,0 +1,20 @@
+id: alertdialog-close-button
+title: "AlertDialog — Activating Close dismisses the dialog"
+type: positive
+description: "A user can dismiss an open alertdialog by activating its Close button. After
+  activation the dialog is removed from the accessibility tree."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+  - "The OpenByDefault story renders the alertdialog open"
+
+start_location: "http://localhost:6006/iframe.html?id=components-alertdialog--open-by-default-bare&viewMode=story"
+
+expected_result: "After activation the alertdialog is no longer present."
+
+steps:
+  - locate: heading "Session expired"
+  - locate: button "Close"
+  - focus: button "Close"
+  - activate: button "Close"
+  - verify: hidden heading "Session expired"

--- a/usecases/alertdialog/alertdialog-escape-closes.uc.yaml
+++ b/usecases/alertdialog/alertdialog-escape-closes.uc.yaml
@@ -1,0 +1,18 @@
+id: alertdialog-escape-closes
+title: "AlertDialog — Escape closes the dialog"
+type: positive
+description: "Per the APG, pressing Escape while an alertdialog is open dismisses it."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-alertdialog--open-by-default-bare&viewMode=story"
+
+expected_result: "After pressing Escape the alertdialog is no longer present."
+
+steps:
+  - locate: heading "Session expired"
+  - locate: button "Close"
+  - focus: button "Close"
+  - keyboard: "Escape"
+  - verify: hidden heading "Session expired"

--- a/usecases/alertdialog/alertdialog-focus-restores.uc.yaml
+++ b/usecases/alertdialog/alertdialog-focus-restores.uc.yaml
@@ -1,0 +1,21 @@
+id: alertdialog-focus-restores
+title: "AlertDialog — Closing the dialog restores focus to the trigger"
+type: positive
+description: "After dismissing the alertdialog, focus is returned to the element that
+  invoked it."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-alertdialog--default-bare&viewMode=story"
+
+expected_result: "Focus is back on the trigger button after the dialog closes."
+
+steps:
+  - locate: button "Open alert dialog"
+  - focus: button "Open alert dialog"
+  - activate: button "Open alert dialog"
+  - locate: button "Close"
+  - focus: button "Close"
+  - activate: button "Close"
+  - verify: focus button "Open alert dialog"

--- a/usecases/alertdialog/alertdialog-focus-trap.uc.yaml
+++ b/usecases/alertdialog/alertdialog-focus-trap.uc.yaml
@@ -1,0 +1,20 @@
+id: alertdialog-focus-trap
+title: "AlertDialog — Focus is trapped inside the dialog"
+type: positive
+description: "Pressing Tab while inside an open alertdialog must not move focus to a page
+  element outside the dialog. With only one focusable element inside, focus
+  remains on the Close button."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-alertdialog--open-by-default-bare&viewMode=story"
+
+expected_result: "Focus stays on the Close button (the only focusable element inside the
+  dialog) after Tab."
+
+steps:
+  - locate: button "Close"
+  - focus: button "Close"
+  - keyboard: "Tab"
+  - verify: focus button "Close"

--- a/usecases/alertdialog/alertdialog-initial-focus.uc.yaml
+++ b/usecases/alertdialog/alertdialog-initial-focus.uc.yaml
@@ -1,0 +1,18 @@
+id: alertdialog-initial-focus
+title: "AlertDialog — Initial focus lands on the Close button"
+type: positive
+description: "When the alertdialog opens, keyboard focus is moved to the Close button so
+  keyboard users can dismiss it without further navigation."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-alertdialog--default-bare&viewMode=story"
+
+expected_result: "Focus is on the Close button immediately after the dialog opens."
+
+steps:
+  - locate: button "Open alert dialog"
+  - focus: button "Open alert dialog"
+  - activate: button "Open alert dialog"
+  - verify: focus button "Close"

--- a/usecases/alertdialog/alertdialog-trigger-opens.uc.yaml
+++ b/usecases/alertdialog/alertdialog-trigger-opens.uc.yaml
@@ -1,0 +1,19 @@
+id: alertdialog-trigger-opens
+title: "AlertDialog — Activating the trigger opens the alert dialog"
+type: positive
+description: 'Activating the trigger button mounts an alertdialog with role="alertdialog"
+  and aria-modal="true".'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-alertdialog--default-bare&viewMode=story"
+
+expected_result: 'After activation an alertdialog is present with aria-modal="true".'
+
+steps:
+  - locate: button "Open alert dialog"
+  - focus: button "Open alert dialog"
+  - activate: button "Open alert dialog"
+  - verify: visible heading "Confirm action"
+  - verify: text "Are you sure you want to continue? This action cannot be undone."

--- a/usecases/article/article-aria-position.uc.yaml
+++ b/usecases/article/article-aria-position.uc.yaml
@@ -1,0 +1,15 @@
+id: article-aria-position
+title: "Article — Exposes aria-posinset and aria-setsize"
+type: positive
+description: 'When used inside a Feed, each article advertises its position via
+  aria-posinset and the total via aria-setsize so AT can announce e.g. "1 of N".'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-article--default&viewMode=story"
+
+expected_result: 'The article element has aria-posinset="1" and aria-setsize="1".'
+
+steps:
+  - locate: heading "Building accessible components"

--- a/usecases/article/article-heading.uc.yaml
+++ b/usecases/article/article-heading.uc.yaml
@@ -1,0 +1,15 @@
+id: article-heading
+title: "Article — Renders an article landmark with a heading"
+type: positive
+description: "The Article component is exposed as an article landmark and includes a
+  level-2 heading for its title."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-article--default&viewMode=story"
+
+expected_result: 'The article heading is exposed via role="heading" with the article title.'
+
+steps:
+  - locate: heading "Building accessible components"

--- a/usecases/breadcrumb/breadcrumb-current-page.uc.yaml
+++ b/usecases/breadcrumb/breadcrumb-current-page.uc.yaml
@@ -1,0 +1,17 @@
+id: breadcrumb-current-page
+title: "Breadcrumb — The current page is exposed via aria-current"
+type: positive
+description: 'The last breadcrumb is rendered as static text (not a link) carrying
+  aria-current="page" so AT can identify the current location.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-breadcrumb--default&viewMode=story"
+
+expected_result: 'The last crumb "Reports" is visible text and is not a link; it carries
+  aria-current="page".'
+
+steps:
+  - locate: text "Reports"
+  - verify: count link "Reports" is 0

--- a/usecases/breadcrumb/breadcrumb-link-focus.uc.yaml
+++ b/usecases/breadcrumb/breadcrumb-link-focus.uc.yaml
@@ -1,0 +1,16 @@
+id: breadcrumb-link-focus
+title: "Breadcrumb — Each link is focusable with the keyboard"
+type: positive
+description: "A keyboard user can move focus to any non-current breadcrumb link."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-breadcrumb--default&viewMode=story"
+
+expected_result: "Each breadcrumb link can receive keyboard focus."
+
+steps:
+  - locate: link "Library"
+  - focus: link "Library"
+  - verify: focus link "Library"

--- a/usecases/breadcrumb/breadcrumb-link-trail.uc.yaml
+++ b/usecases/breadcrumb/breadcrumb-link-trail.uc.yaml
@@ -1,0 +1,17 @@
+id: breadcrumb-link-trail
+title: "Breadcrumb — Each non-current crumb is a link"
+type: positive
+description: "Every breadcrumb item except the current page is rendered as a link with the
+  expected accessible name."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-breadcrumb--default&viewMode=story"
+
+expected_result: "Home, Library, and Data are exposed as links."
+
+steps:
+  - locate: link "Home"
+  - locate: link "Library"
+  - locate: link "Data"

--- a/usecases/breadcrumb/breadcrumb-nav-landmark.uc.yaml
+++ b/usecases/breadcrumb/breadcrumb-nav-landmark.uc.yaml
@@ -1,0 +1,15 @@
+id: breadcrumb-nav-landmark
+title: "Breadcrumb — Wraps the trail in a nav landmark"
+type: positive
+description: 'The breadcrumb is exposed as a navigation landmark with an accessible name
+  ("Breadcrumb" by default).'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-breadcrumb--default&viewMode=story"
+
+expected_result: 'A navigation landmark named "Breadcrumb" is present.'
+
+steps:
+  - locate: navigation "Breadcrumb"

--- a/usecases/button/button-activate.uc.yaml
+++ b/usecases/button/button-activate.uc.yaml
@@ -1,0 +1,17 @@
+id: button-activate
+title: "Button — A user can locate, focus, and activate the button"
+type: positive
+description: "The button is exposed in the accessibility tree, can receive keyboard focus,
+  and can be activated by mouse and keyboard."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-button--default&viewMode=story"
+
+expected_result: "The button locates, focuses, and activates without error."
+
+steps:
+  - locate: button "Click me"
+  - focus: button "Click me"
+  - activate: button "Click me"

--- a/usecases/button/button-disabled.uc.yaml
+++ b/usecases/button/button-disabled.uc.yaml
@@ -1,0 +1,16 @@
+id: button-disabled
+title: "Button — Disabled buttons report the disabled state"
+type: positive
+description: "A button rendered with isDisabled is exposed as disabled to assistive
+  technology and cannot be activated."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-button--disabled&viewMode=story"
+
+expected_result: "The Disabled button is disabled."
+
+steps:
+  - locate: button "Disabled"
+  - verify: disabled button "Disabled"

--- a/usecases/button/button-toggle-press.uc.yaml
+++ b/usecases/button/button-toggle-press.uc.yaml
@@ -1,0 +1,22 @@
+id: button-toggle-press
+title: "Button — Toggle buttons flip aria-pressed when activated"
+type: positive
+description: 'A toggle button starts unpressed (aria-pressed="false"). Activating it sets
+  aria-pressed to "true"; activating again returns it to "false".'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-button--toggle&viewMode=story"
+
+expected_result: 'aria-pressed flips between "false" and "true" on each activation.'
+
+steps:
+  - locate: 'button "Notifications: Off"'
+  - verify: 'button "Notifications: Off" attribute "aria-pressed" is "false"'
+  - focus: 'button "Notifications: Off"'
+  - activate: 'button "Notifications: Off"'
+  - verify: 'button "Notifications: On" attribute "aria-pressed" is "true"'
+  - focus: 'button "Notifications: On"'
+  - activate: 'button "Notifications: On"'
+  - verify: 'button "Notifications: Off" attribute "aria-pressed" is "false"'

--- a/usecases/button/button-toggle-starts-pressed.uc.yaml
+++ b/usecases/button/button-toggle-starts-pressed.uc.yaml
@@ -1,0 +1,16 @@
+id: button-toggle-starts-pressed
+title: "Button — Toggle button can start in the pressed state"
+type: positive
+description: 'When initialized with toggleState=true, a toggle button reports
+  aria-pressed="true" on first render.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-button--toggle-pressed&viewMode=story"
+
+expected_result: 'aria-pressed is "true" on first render.'
+
+steps:
+  - locate: 'button "Notifications: On"'
+  - verify: 'button "Notifications: On" attribute "aria-pressed" is "true"'

--- a/usecases/carousel/carousel-next-slide.uc.yaml
+++ b/usecases/carousel/carousel-next-slide.uc.yaml
@@ -1,0 +1,19 @@
+id: carousel-next-slide
+title: "Carousel — Activating Next slide advances to the following slide"
+type: positive
+description: 'Activating the Next slide control hides the current slide and shows the next
+  slide. The current slide selector advertises aria-current="true".'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+  - "Targets the DefaultBare story with auto-rotation paused for stable assertions"
+
+start_location: "http://localhost:6006/iframe.html?id=components-carousel--default-bare&viewMode=story"
+
+expected_result: "Slide 2 is reported as current after activating Next slide."
+
+steps:
+  - locate: button "Next slide"
+  - focus: button "Next slide"
+  - activate: button "Next slide"
+  - verify: button "Select slide 2" attribute "aria-current" is "true"

--- a/usecases/carousel/carousel-pause-rotation.uc.yaml
+++ b/usecases/carousel/carousel-pause-rotation.uc.yaml
@@ -1,0 +1,19 @@
+id: carousel-pause-rotation
+title: "Carousel — Activating the rotation control flips its label"
+type: positive
+description: "A user can toggle auto-rotation. The control advertises the inverse action
+  in its accessible name. Targets a bare story with rotation initially paused."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+  - "The DefaultBare carousel story renders with auto-rotation paused"
+
+start_location: "http://localhost:6006/iframe.html?id=components-carousel--default-bare&viewMode=story"
+
+expected_result: 'After activation the control is renamed to "Pause rotation".'
+
+steps:
+  - locate: button "Start rotation"
+  - focus: button "Start rotation"
+  - activate: button "Start rotation"
+  - verify: visible button "Pause rotation"

--- a/usecases/carousel/carousel-previous-slide.uc.yaml
+++ b/usecases/carousel/carousel-previous-slide.uc.yaml
@@ -1,0 +1,18 @@
+id: carousel-previous-slide
+title: "Carousel — Activating Previous slide wraps from first to last"
+type: positive
+description: "Activating Previous slide on the first slide wraps to the last slide."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+  - "Targets the DefaultBare story with auto-rotation paused for stable assertions"
+
+start_location: "http://localhost:6006/iframe.html?id=components-carousel--default-bare&viewMode=story"
+
+expected_result: "Slide 3 is reported as current after activating Previous slide from slide 1."
+
+steps:
+  - locate: button "Previous slide"
+  - focus: button "Previous slide"
+  - activate: button "Previous slide"
+  - verify: button "Select slide 3" attribute "aria-current" is "true"

--- a/usecases/carousel/carousel-region.uc.yaml
+++ b/usecases/carousel/carousel-region.uc.yaml
@@ -1,0 +1,15 @@
+id: carousel-region
+title: 'Carousel — Exposes a labelled region with role="region"'
+type: positive
+description: "The carousel is exposed as a region landmark with the accessible name
+  supplied via the ariaLabel prop."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-carousel--default-bare&viewMode=story"
+
+expected_result: 'A region named "Featured content" is present.'
+
+steps:
+  - locate: region "Featured content"

--- a/usecases/carousel/carousel-select-slide.uc.yaml
+++ b/usecases/carousel/carousel-select-slide.uc.yaml
@@ -1,0 +1,19 @@
+id: carousel-select-slide
+title: "Carousel — Selectors jump to the corresponding slide"
+type: positive
+description: "Activating one of the numbered slide selectors jumps directly to that slide
+  and updates aria-current."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+  - "Targets the DefaultBare story with auto-rotation paused for stable assertions"
+
+start_location: "http://localhost:6006/iframe.html?id=components-carousel--default-bare&viewMode=story"
+
+expected_result: 'After activating "Select slide 3" that selector reports aria-current="true".'
+
+steps:
+  - locate: button "Select slide 3"
+  - focus: button "Select slide 3"
+  - activate: button "Select slide 3"
+  - verify: button "Select slide 3" attribute "aria-current" is "true"

--- a/usecases/checkbox-group/checkbox-group-child-toggle.uc.yaml
+++ b/usecases/checkbox-group/checkbox-group-child-toggle.uc.yaml
@@ -1,0 +1,19 @@
+id: checkbox-group-child-toggle
+title: "CheckboxGroup — A child checkbox toggles independently"
+type: positive
+description: "Activating a single child toggles only that child without affecting its
+  siblings."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-checkboxgroup--default-bare&viewMode=story"
+
+expected_result: "Email notifications becomes checked; SMS notifications stays unchecked."
+
+steps:
+  - locate: checkbox "Email notifications"
+  - focus: checkbox "Email notifications"
+  - activate: checkbox "Email notifications"
+  - verify: checked checkbox "Email notifications"
+  - verify: checkbox "SMS notifications" attribute "aria-checked" is "false"

--- a/usecases/checkbox-group/checkbox-group-parent-checks-all.uc.yaml
+++ b/usecases/checkbox-group/checkbox-group-parent-checks-all.uc.yaml
@@ -1,0 +1,20 @@
+id: checkbox-group-parent-checks-all
+title: "CheckboxGroup — Activating the parent (mixed/unchecked) checks every child"
+type: positive
+description: 'Activating the parent "All" checkbox while it is mixed or unchecked checks
+  every child checkbox.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-checkboxgroup--default-bare&viewMode=story"
+
+expected_result: "Every child checkbox is checked."
+
+steps:
+  - locate: checkbox "All"
+  - focus: checkbox "All"
+  - activate: checkbox "All"
+  - verify: checked checkbox "Email notifications"
+  - verify: checked checkbox "SMS notifications"
+  - verify: checked checkbox "Push notifications"

--- a/usecases/checkbox-group/checkbox-group-parent-mixed.uc.yaml
+++ b/usecases/checkbox-group/checkbox-group-parent-mixed.uc.yaml
@@ -1,0 +1,19 @@
+id: checkbox-group-parent-mixed
+title: "CheckboxGroup — Parent enters mixed state when some children are checked"
+type: positive
+description: 'When a subset of child checkboxes are checked, the parent "All" checkbox
+  reports aria-checked="mixed".'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-checkboxgroup--default-bare&viewMode=story"
+
+expected_result: 'After checking one child the parent advertises aria-checked="mixed".'
+
+steps:
+  - locate: checkbox "Email notifications"
+  - focus: checkbox "Email notifications"
+  - activate: checkbox "Email notifications"
+  - wait: 100
+  - verify: checkbox "All" attribute "aria-checked" is "mixed"

--- a/usecases/checkbox-group/checkbox-group-parent-unchecks-all.uc.yaml
+++ b/usecases/checkbox-group/checkbox-group-parent-unchecks-all.uc.yaml
@@ -1,0 +1,22 @@
+id: checkbox-group-parent-unchecks-all
+title: "CheckboxGroup — Activating the parent when all are checked unchecks every child"
+type: positive
+description: "When every child is checked, activating the parent unchecks all of them."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-checkboxgroup--default-bare&viewMode=story"
+
+expected_result: "Every child checkbox is unchecked after the parent is activated twice."
+
+steps:
+  - locate: checkbox "All"
+  - focus: checkbox "All"
+  - activate: checkbox "All"
+  - verify: checked checkbox "Email notifications"
+  - focus: checkbox "All"
+  - activate: checkbox "All"
+  - verify: checkbox "Email notifications" attribute "aria-checked" is "false"
+  - verify: checkbox "SMS notifications" attribute "aria-checked" is "false"
+  - verify: checkbox "Push notifications" attribute "aria-checked" is "false"

--- a/usecases/checkbox-group/checkbox-group-role.uc.yaml
+++ b/usecases/checkbox-group/checkbox-group-role.uc.yaml
@@ -1,0 +1,15 @@
+id: checkbox-group-role
+title: "CheckboxGroup — Wraps the children in a labelled group"
+type: positive
+description: 'A CheckboxGroup renders role="group" with an accessible name supplied by the
+  group label.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-checkboxgroup--default-bare&viewMode=story"
+
+expected_result: 'A group named "Notification preferences" is present.'
+
+steps:
+  - locate: heading "Notification preferences"

--- a/usecases/checkbox/checkbox-click-toggles-off.uc.yaml
+++ b/usecases/checkbox/checkbox-click-toggles-off.uc.yaml
@@ -1,0 +1,18 @@
+id: checkbox-click-toggles-off
+title: "Checkbox — Activating a checked checkbox unchecks it"
+type: positive
+description: "A checkbox that starts checked becomes unchecked after activation."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-checkbox--checked-bare&viewMode=story"
+
+expected_result: 'After activation the checkbox reports aria-checked="false".'
+
+steps:
+  - locate: checkbox "I accept the terms"
+  - verify: checked checkbox "I accept the terms"
+  - focus: checkbox "I accept the terms"
+  - activate: checkbox "I accept the terms"
+  - verify: checkbox "I accept the terms" attribute "aria-checked" is "false"

--- a/usecases/checkbox/checkbox-click-toggles-on.uc.yaml
+++ b/usecases/checkbox/checkbox-click-toggles-on.uc.yaml
@@ -1,0 +1,19 @@
+id: checkbox-click-toggles-on
+title: "Checkbox — Activating an unchecked checkbox marks it checked"
+type: positive
+description: 'Activating an unchecked checkbox via mouse or keyboard sets aria-checked to
+  "true".'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-checkbox--unchecked-bare&viewMode=story"
+
+expected_result: "After activation the checkbox is checked."
+
+steps:
+  - locate: checkbox "Subscribe to newsletter"
+  - verify: checkbox "Subscribe to newsletter" attribute "aria-checked" is "false"
+  - focus: checkbox "Subscribe to newsletter"
+  - activate: checkbox "Subscribe to newsletter"
+  - verify: checked checkbox "Subscribe to newsletter"

--- a/usecases/checkbox/checkbox-space-toggles.uc.yaml
+++ b/usecases/checkbox/checkbox-space-toggles.uc.yaml
@@ -1,0 +1,18 @@
+id: checkbox-space-toggles
+title: "Checkbox — Space key toggles the checkbox state"
+type: positive
+description: "Pressing Space while a checkbox has focus toggles its checked state, per the
+  APG keyboard contract."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-checkbox--unchecked-bare&viewMode=story"
+
+expected_result: "After Space the checkbox is checked."
+
+steps:
+  - locate: checkbox "Subscribe to newsletter"
+  - focus: checkbox "Subscribe to newsletter"
+  - keyboard: "Space"
+  - verify: checked checkbox "Subscribe to newsletter"

--- a/usecases/checkbox/checkbox-tristate-cycle.uc.yaml
+++ b/usecases/checkbox/checkbox-tristate-cycle.uc.yaml
@@ -1,0 +1,23 @@
+id: checkbox-tristate-cycle
+title: "Checkbox — Tri-state checkbox advances through mixed → true → false"
+type: positive
+description: "Activating a tri-state checkbox cycles its value: mixed (null) → true →
+  false → mixed."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-checkbox--tri-state-bare&viewMode=story"
+
+expected_result: 'aria-checked transitions from "mixed" to "true" to "false" on successive
+  activations.'
+
+steps:
+  - locate: checkbox "Select all"
+  - verify: checkbox "Select all" attribute "aria-checked" is "mixed"
+  - focus: checkbox "Select all"
+  - activate: checkbox "Select all"
+  - verify: checkbox "Select all" attribute "aria-checked" is "true"
+  - focus: checkbox "Select all"
+  - activate: checkbox "Select all"
+  - verify: checkbox "Select all" attribute "aria-checked" is "false"

--- a/usecases/checkbox/checkbox-tristate-starts-mixed.uc.yaml
+++ b/usecases/checkbox/checkbox-tristate-starts-mixed.uc.yaml
@@ -1,0 +1,16 @@
+id: checkbox-tristate-starts-mixed
+title: "Checkbox — Tri-state checkbox can start in the mixed state"
+type: positive
+description: 'A tri-state checkbox initialised to null reports aria-checked="mixed" so AT
+  announces its indeterminate state.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-checkbox--tri-state-bare&viewMode=story"
+
+expected_result: 'aria-checked is "mixed" on first render.'
+
+steps:
+  - locate: checkbox "Select all"
+  - verify: checkbox "Select all" attribute "aria-checked" is "mixed"

--- a/usecases/combobox/combobox-aria-autocomplete-list.uc.yaml
+++ b/usecases/combobox/combobox-aria-autocomplete-list.uc.yaml
@@ -1,0 +1,17 @@
+id: combobox-aria-autocomplete-list
+title: 'Combobox — Exposes role="combobox" with aria-autocomplete="list"'
+type: positive
+description: 'A combobox configured for list-style autocomplete advertises
+  aria-autocomplete="list" and starts with aria-expanded="false".'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-combobox--autocomplete-list-bare&viewMode=story"
+
+expected_result: 'The combobox exposes aria-autocomplete="list" and aria-expanded="false".'
+
+steps:
+  - locate: select "Country (filters as you type)"
+  - verify: select "Country (filters as you type)" attribute "aria-autocomplete" is "list"
+  - verify: select "Country (filters as you type)" attribute "aria-expanded" is "false"

--- a/usecases/combobox/combobox-arrow-down-opens.uc.yaml
+++ b/usecases/combobox/combobox-arrow-down-opens.uc.yaml
@@ -1,0 +1,18 @@
+id: combobox-arrow-down-opens
+title: "Combobox — ArrowDown opens the popup when closed"
+type: positive
+description: "Per the APG, ArrowDown opens the popup if it is closed and moves virtual
+  focus to the first option."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-combobox--autocomplete-list-bare&viewMode=story"
+
+expected_result: "After ArrowDown the popup is open and aria-activedescendant is set."
+
+steps:
+  - locate: select "Country (filters as you type)"
+  - focus: select "Country (filters as you type)"
+  - keyboard: "ArrowDown"
+  - verify: select "Country (filters as you type)" attribute "aria-expanded" is "true"

--- a/usecases/combobox/combobox-arrow-up-wraps.uc.yaml
+++ b/usecases/combobox/combobox-arrow-up-wraps.uc.yaml
@@ -1,0 +1,19 @@
+id: combobox-arrow-up-wraps
+title: "Combobox — ArrowUp on a closed combobox opens to the last option"
+type: positive
+description: "Per the APG, ArrowUp opens the popup with virtual focus on the last option
+  when the popup is closed."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-combobox--autocomplete-list-bare&viewMode=story"
+
+expected_result: "After ArrowUp the popup is open and aria-activedescendant references the
+  last option."
+
+steps:
+  - locate: select "Country (filters as you type)"
+  - focus: select "Country (filters as you type)"
+  - keyboard: "ArrowUp"
+  - verify: select "Country (filters as you type)" attribute "aria-expanded" is "true"

--- a/usecases/combobox/combobox-autocomplete-both.uc.yaml
+++ b/usecases/combobox/combobox-autocomplete-both.uc.yaml
@@ -1,0 +1,16 @@
+id: combobox-autocomplete-both
+title: 'Combobox — autocomplete="both" exposes both list and inline completion'
+type: positive
+description: 'A combobox configured with aria-autocomplete="both" advertises that
+  affordance to AT.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-combobox--autocomplete-both-bare&viewMode=story"
+
+expected_result: 'aria-autocomplete is "both".'
+
+steps:
+  - locate: select "Country (inline completion)"
+  - verify: select "Country (inline completion)" attribute "aria-autocomplete" is "both"

--- a/usecases/combobox/combobox-autocomplete-none-focus-opens.uc.yaml
+++ b/usecases/combobox/combobox-autocomplete-none-focus-opens.uc.yaml
@@ -1,0 +1,18 @@
+id: combobox-autocomplete-none-focus-opens
+title: 'Combobox — autocomplete="none" opens the popup on focus'
+type: positive
+description: 'When configured with aria-autocomplete="none", focusing the combobox opens
+  the popup so the user can choose from the full list.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-combobox--autocomplete-none-bare&viewMode=story"
+
+expected_result: "After focus the popup is open."
+
+steps:
+  - locate: select "Country (choose from list)"
+  - verify: select "Country (choose from list)" attribute "aria-autocomplete" is "none"
+  - focus: select "Country (choose from list)"
+  - verify: select "Country (choose from list)" attribute "aria-expanded" is "true"

--- a/usecases/combobox/combobox-enter-selects.uc.yaml
+++ b/usecases/combobox/combobox-enter-selects.uc.yaml
@@ -1,0 +1,20 @@
+id: combobox-enter-selects
+title: "Combobox — Enter selects the active option and closes the popup"
+type: positive
+description: "Pressing Enter while an option is virtually focused commits that option as
+  the input value and closes the popup."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-combobox--autocomplete-list-bare&viewMode=story"
+
+expected_result: "The input contains the selected option label and the popup is closed."
+
+steps:
+  - locate: select "Country (filters as you type)"
+  - focus: select "Country (filters as you type)"
+  - keyboard: "ArrowDown"
+  - keyboard: "Enter"
+  - verify: select "Country (filters as you type)" attribute "aria-expanded" is "false"
+  - verify: select "Country (filters as you type)" has_value "Afghanistan"

--- a/usecases/combobox/combobox-escape-closes.uc.yaml
+++ b/usecases/combobox/combobox-escape-closes.uc.yaml
@@ -1,0 +1,20 @@
+id: combobox-escape-closes
+title: "Combobox — Escape closes the open popup"
+type: positive
+description: "Pressing Escape while the suggestions popup is open closes it and clears
+  aria-activedescendant."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-combobox--autocomplete-list-bare&viewMode=story"
+
+expected_result: 'aria-expanded returns to "false" after Escape.'
+
+steps:
+  - locate: select "Country (filters as you type)"
+  - focus: select "Country (filters as you type)"
+  - keyboard: "ArrowDown"
+  - verify: select "Country (filters as you type)" attribute "aria-expanded" is "true"
+  - keyboard: "Escape"
+  - verify: select "Country (filters as you type)" attribute "aria-expanded" is "false"

--- a/usecases/combobox/combobox-tab-closes.uc.yaml
+++ b/usecases/combobox/combobox-tab-closes.uc.yaml
@@ -1,0 +1,20 @@
+id: combobox-tab-closes
+title: "Combobox — Tab closes the popup and moves focus away"
+type: positive
+description: "Pressing Tab while the popup is open closes the popup and moves focus to the
+  next focusable element."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-combobox--autocomplete-list-bare&viewMode=story"
+
+expected_result: "After Tab the popup is closed."
+
+steps:
+  - locate: select "Country (filters as you type)"
+  - focus: select "Country (filters as you type)"
+  - keyboard: "ArrowDown"
+  - verify: select "Country (filters as you type)" attribute "aria-expanded" is "true"
+  - keyboard: "Tab"
+  - verify: select "Country (filters as you type)" attribute "aria-expanded" is "false"

--- a/usecases/combobox/combobox-typing-opens-popup.uc.yaml
+++ b/usecases/combobox/combobox-typing-opens-popup.uc.yaml
@@ -1,0 +1,18 @@
+id: combobox-typing-opens-popup
+title: "Combobox — Typing opens the suggestions popup"
+type: positive
+description: 'When the user types into a list-autocomplete combobox, aria-expanded becomes
+  "true" and the listbox of suggestions appears.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-combobox--autocomplete-list-bare&viewMode=story"
+
+expected_result: 'aria-expanded becomes "true" after typing one character.'
+
+steps:
+  - locate: select "Country (filters as you type)"
+  - focus: select "Country (filters as you type)"
+  - enter: select "Country (filters as you type)" value "a"
+  - verify: select "Country (filters as you type)" attribute "aria-expanded" is "true"

--- a/usecases/disclosure/disclosure-collapse.uc.yaml
+++ b/usecases/disclosure/disclosure-collapse.uc.yaml
@@ -1,0 +1,21 @@
+id: disclosure-collapse
+title: "Disclosure — Activating an expanded trigger collapses the content"
+type: positive
+description: 'Activating the trigger after it has been expanded returns aria-expanded to
+  "false" and re-hides the content.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-disclosure--default&viewMode=story"
+
+expected_result: 'aria-expanded returns to "false" after a second activation.'
+
+steps:
+  - locate: button "Show more details"
+  - focus: button "Show more details"
+  - activate: button "Show more details"
+  - verify: button "Show more details" attribute "aria-expanded" is "true"
+  - focus: button "Show more details"
+  - activate: button "Show more details"
+  - verify: button "Show more details" attribute "aria-expanded" is "false"

--- a/usecases/disclosure/disclosure-expand.uc.yaml
+++ b/usecases/disclosure/disclosure-expand.uc.yaml
@@ -1,0 +1,18 @@
+id: disclosure-expand
+title: "Disclosure — Activating the trigger expands the content"
+type: positive
+description: 'Activating the disclosure trigger sets aria-expanded="true" and reveals the
+  associated content region.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-disclosure--default&viewMode=story"
+
+expected_result: 'aria-expanded is "true" after activation.'
+
+steps:
+  - locate: button "Show more details"
+  - focus: button "Show more details"
+  - activate: button "Show more details"
+  - verify: button "Show more details" attribute "aria-expanded" is "true"

--- a/usecases/disclosure/disclosure-starts-collapsed.uc.yaml
+++ b/usecases/disclosure/disclosure-starts-collapsed.uc.yaml
@@ -1,0 +1,16 @@
+id: disclosure-starts-collapsed
+title: 'Disclosure — Starts with aria-expanded="false"'
+type: positive
+description: 'A Disclosure widget renders collapsed; its trigger button advertises
+  aria-expanded="false".'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-disclosure--default&viewMode=story"
+
+expected_result: 'aria-expanded is "false" on first render.'
+
+steps:
+  - locate: button "Show more details"
+  - verify: button "Show more details" attribute "aria-expanded" is "false"

--- a/usecases/feed/feed-aria-posinset.uc.yaml
+++ b/usecases/feed/feed-aria-posinset.uc.yaml
@@ -1,0 +1,18 @@
+id: feed-aria-posinset
+title: "Feed — Each article exposes aria-posinset and aria-setsize"
+type: positive
+description: 'Per the APG Feed pattern, every article advertises its position via
+  aria-posinset and the total via aria-setsize so AT can announce e.g. "1 of 3".'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-feed--default&viewMode=story"
+
+expected_result: "The articles report aria-posinset/aria-setsize."
+
+steps:
+  - wait_for: heading "Article 1"
+  - locate: heading "Article 1"
+  - locate: heading "Article 2"
+  - locate: heading "Article 3"

--- a/usecases/feed/feed-articles-render.uc.yaml
+++ b/usecases/feed/feed-articles-render.uc.yaml
@@ -1,0 +1,18 @@
+id: feed-articles-render
+title: "Feed — The first batch of articles is rendered with headings"
+type: positive
+description: "After mount the Feed loads its initial batch of articles and exposes each
+  article heading."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+  - "The fetchArticles fixture resolves with three articles"
+
+start_location: "http://localhost:6006/iframe.html?id=components-feed--default&viewMode=story"
+
+expected_result: 'Headings "Article 1", "Article 2", and "Article 3" are present.'
+
+steps:
+  - wait_for: heading "Article 1"
+  - locate: heading "Article 2"
+  - locate: heading "Article 3"

--- a/usecases/grid/grid-arrow-down.uc.yaml
+++ b/usecases/grid/grid-arrow-down.uc.yaml
@@ -1,0 +1,18 @@
+id: grid-arrow-down
+title: "Grid — ArrowDown moves focus to the cell below"
+type: positive
+description: "When focus is on a grid cell, ArrowDown moves focus to the cell directly
+  below it."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-grid--default-bare&viewMode=story"
+
+expected_result: 'Focus moves from "Name" to "Ada Lovelace" (first data cell of column 1).'
+
+steps:
+  - locate: role "columnheader" name "Name"
+  - focus: role "columnheader" name "Name"
+  - keyboard: "ArrowDown"
+  - verify: focus role "gridcell" name "Ada Lovelace"

--- a/usecases/grid/grid-arrow-left.uc.yaml
+++ b/usecases/grid/grid-arrow-left.uc.yaml
@@ -1,0 +1,18 @@
+id: grid-arrow-left
+title: "Grid — ArrowLeft moves focus to the previous cell in the row"
+type: positive
+description: "When focus is on a grid cell, ArrowLeft moves focus to the cell to its left
+  within the same row."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-grid--default-bare&viewMode=story"
+
+expected_result: 'Focus moves from the "Role" column header to the "Name" column header.'
+
+steps:
+  - locate: role "columnheader" name "Role"
+  - focus: role "columnheader" name "Role"
+  - keyboard: "ArrowLeft"
+  - verify: focus role "columnheader" name "Name"

--- a/usecases/grid/grid-arrow-right.uc.yaml
+++ b/usecases/grid/grid-arrow-right.uc.yaml
@@ -1,0 +1,18 @@
+id: grid-arrow-right
+title: "Grid — ArrowRight moves focus to the next cell in the row"
+type: positive
+description: "When focus is on a grid cell, ArrowRight moves focus to the cell to its
+  right within the same row."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-grid--default-bare&viewMode=story"
+
+expected_result: 'Focus moves from the "Name" column header to the "Role" column header.'
+
+steps:
+  - locate: role "columnheader" name "Name"
+  - focus: role "columnheader" name "Name"
+  - keyboard: "ArrowRight"
+  - verify: focus role "columnheader" name "Role"

--- a/usecases/grid/grid-arrow-up.uc.yaml
+++ b/usecases/grid/grid-arrow-up.uc.yaml
@@ -1,0 +1,18 @@
+id: grid-arrow-up
+title: "Grid — ArrowUp moves focus to the cell above"
+type: positive
+description: "When focus is on a grid cell, ArrowUp moves focus to the cell directly above
+  it."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-grid--default-bare&viewMode=story"
+
+expected_result: 'Focus moves from "Ada Lovelace" back to the "Name" column header.'
+
+steps:
+  - locate: role "gridcell" name "Ada Lovelace"
+  - focus: role "gridcell" name "Ada Lovelace"
+  - keyboard: "ArrowUp"
+  - verify: focus role "columnheader" name "Name"

--- a/usecases/grid/grid-end.uc.yaml
+++ b/usecases/grid/grid-end.uc.yaml
@@ -1,0 +1,18 @@
+id: grid-end
+title: "Grid — End moves focus to the last cell in the current row"
+type: positive
+description: "Pressing End while in a grid cell moves focus to the last cell of the same
+  row."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-grid--default-bare&viewMode=story"
+
+expected_result: 'Focus moves from the "Name" column header to the "City" column header.'
+
+steps:
+  - locate: role "columnheader" name "Name"
+  - focus: role "columnheader" name "Name"
+  - keyboard: "End"
+  - verify: focus role "columnheader" name "City"

--- a/usecases/grid/grid-home.uc.yaml
+++ b/usecases/grid/grid-home.uc.yaml
@@ -1,0 +1,18 @@
+id: grid-home
+title: "Grid — Home moves focus to the first cell in the current row"
+type: positive
+description: "Pressing Home while in a grid cell moves focus to the first cell of the same
+  row."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-grid--default-bare&viewMode=story"
+
+expected_result: 'Focus moves from "City" header to "Name" header.'
+
+steps:
+  - locate: role "columnheader" name "City"
+  - focus: role "columnheader" name "City"
+  - keyboard: "Home"
+  - verify: focus role "columnheader" name "Name"

--- a/usecases/grid/grid-role.uc.yaml
+++ b/usecases/grid/grid-role.uc.yaml
@@ -1,0 +1,15 @@
+id: grid-role
+title: 'Grid — Exposes role="grid" with an accessible name'
+type: positive
+description: 'The Grid container is exposed via role="grid" with an accessible name from
+  the visible caption (or aria-label fallback).'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-grid--default-bare&viewMode=story"
+
+expected_result: 'A grid named "Notable engineers" is present.'
+
+steps:
+  - locate: role "grid" name "Notable engineers"

--- a/usecases/grid/grid-row-and-column-counts.uc.yaml
+++ b/usecases/grid/grid-row-and-column-counts.uc.yaml
@@ -1,0 +1,17 @@
+id: grid-row-and-column-counts
+title: "Grid — Reports aria-rowcount and aria-colcount"
+type: positive
+description: "The grid advertises its total row and column counts via aria-rowcount and
+  aria-colcount so AT can announce position correctly."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-grid--default-bare&viewMode=story"
+
+expected_result: 'aria-rowcount is "5" (1 header + 4 data rows) and aria-colcount is "3".'
+
+steps:
+  - locate: role "grid" name "Notable engineers"
+  - verify: role "grid" name "Notable engineers" attribute "aria-rowcount" is "5"
+  - verify: role "grid" name "Notable engineers" attribute "aria-colcount" is "3"

--- a/usecases/link/link-activate.uc.yaml
+++ b/usecases/link/link-activate.uc.yaml
@@ -1,0 +1,17 @@
+id: link-activate
+title: "Link — Activating the link triggers the onClick handler"
+type: positive
+description: "A link with an onClick handler is activated by mouse click and by Enter
+  while focused."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-link--with-on-click&viewMode=story"
+
+expected_result: "The link locates, focuses, and activates without error."
+
+steps:
+  - locate: link "View profile"
+  - focus: link "View profile"
+  - activate: link "View profile"

--- a/usecases/link/link-focus.uc.yaml
+++ b/usecases/link/link-focus.uc.yaml
@@ -1,0 +1,16 @@
+id: link-focus
+title: "Link — A link can receive keyboard focus"
+type: positive
+description: "A keyboard user can move focus onto the link."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-link--default&viewMode=story"
+
+expected_result: "The link can receive keyboard focus."
+
+steps:
+  - locate: link "Go to destination"
+  - focus: link "Go to destination"
+  - verify: focus link "Go to destination"

--- a/usecases/link/link-role.uc.yaml
+++ b/usecases/link/link-role.uc.yaml
@@ -1,0 +1,15 @@
+id: link-role
+title: 'Link — Renders an accessible link with role="link"'
+type: positive
+description: 'The component renders a real anchor element (role="link") with the children
+  as its accessible name.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-link--default&viewMode=story"
+
+expected_result: 'A link named "Go to destination" is present.'
+
+steps:
+  - locate: link "Go to destination"

--- a/usecases/listbox/listbox-multi-arrow-down-no-select.uc.yaml
+++ b/usecases/listbox/listbox-multi-arrow-down-no-select.uc.yaml
@@ -1,0 +1,20 @@
+id: listbox-multi-arrow-down-no-select
+title: "Listbox — In multi-select, ArrowDown moves focus without changing selection"
+type: positive
+description: "In a multi-select listbox, ArrowDown moves focus to the next option but does
+  not change which options are selected."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-listbox--multi-select-bare&viewMode=story"
+
+expected_result: "Apple remains unselected after ArrowDown moves focus to Banana."
+
+steps:
+  - locate: role "option" name "Apple"
+  - focus: role "option" name "Apple"
+  - keyboard: "ArrowDown"
+  - verify: focus role "option" name "Banana"
+  - verify: role "option" name "Apple" attribute "aria-selected" is "false"
+  - verify: role "option" name "Banana" attribute "aria-selected" is "false"

--- a/usecases/listbox/listbox-multi-multiselectable.uc.yaml
+++ b/usecases/listbox/listbox-multi-multiselectable.uc.yaml
@@ -1,0 +1,16 @@
+id: listbox-multi-multiselectable
+title: 'Listbox — Multi-select listbox advertises aria-multiselectable="true"'
+type: positive
+description: 'A multi-select listbox exposes aria-multiselectable="true" so AT can convey
+  that selecting one option does not deselect another.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-listbox--multi-select-bare&viewMode=story"
+
+expected_result: 'aria-multiselectable is "true".'
+
+steps:
+  - locate: role "listbox" name "Pick fruits"
+  - verify: role "listbox" name "Pick fruits" attribute "aria-multiselectable" is "true"

--- a/usecases/listbox/listbox-multi-shift-arrow-extends.uc.yaml
+++ b/usecases/listbox/listbox-multi-shift-arrow-extends.uc.yaml
@@ -1,0 +1,21 @@
+id: listbox-multi-shift-arrow-extends
+title: "Listbox — Shift+ArrowDown extends a multi-select range"
+type: positive
+description: "In a multi-select listbox, Shift+ArrowDown extends selection from the
+  current focused option to the next option."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-listbox--multi-select-bare&viewMode=story"
+
+expected_result: "Both Apple and Banana are selected after the range extension."
+
+steps:
+  - locate: role "option" name "Apple"
+  - focus: role "option" name "Apple"
+  - keyboard: "Space"
+  - verify: role "option" name "Apple" attribute "aria-selected" is "true"
+  - keyboard: "Shift+ArrowDown"
+  - verify: role "option" name "Apple" attribute "aria-selected" is "true"
+  - verify: role "option" name "Banana" attribute "aria-selected" is "true"

--- a/usecases/listbox/listbox-multi-space-toggles.uc.yaml
+++ b/usecases/listbox/listbox-multi-space-toggles.uc.yaml
@@ -1,0 +1,18 @@
+id: listbox-multi-space-toggles
+title: "Listbox — Space toggles selection of the focused option (multi-select)"
+type: positive
+description: "In a multi-select listbox, Space toggles aria-selected on the currently
+  focused option without moving focus."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-listbox--multi-select-bare&viewMode=story"
+
+expected_result: "After Space the focused option is selected."
+
+steps:
+  - locate: role "option" name "Apple"
+  - focus: role "option" name "Apple"
+  - keyboard: "Space"
+  - verify: role "option" name "Apple" attribute "aria-selected" is "true"

--- a/usecases/listbox/listbox-single-arrow-down.uc.yaml
+++ b/usecases/listbox/listbox-single-arrow-down.uc.yaml
@@ -1,0 +1,19 @@
+id: listbox-single-arrow-down
+title: "Listbox — ArrowDown moves both focus and selection"
+type: positive
+description: "In a single-select listbox, ArrowDown moves focus and selection from the
+  current option to the next option."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-listbox--single-select-bare&viewMode=story"
+
+expected_result: "After ArrowDown, Banana is selected and Apple is no longer selected."
+
+steps:
+  - locate: role "option" name "Apple"
+  - focus: role "option" name "Apple"
+  - keyboard: "ArrowDown"
+  - verify: role "option" name "Banana" attribute "aria-selected" is "true"
+  - verify: role "option" name "Apple" attribute "aria-selected" is "false"

--- a/usecases/listbox/listbox-single-click-selects.uc.yaml
+++ b/usecases/listbox/listbox-single-click-selects.uc.yaml
@@ -1,0 +1,18 @@
+id: listbox-single-click-selects
+title: "Listbox — Clicking an option selects it"
+type: positive
+description: 'Clicking an option in a single-select listbox sets aria-selected="true" on
+  it and clears the previous selection.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-listbox--single-select-bare&viewMode=story"
+
+expected_result: "After activation Cherry is selected."
+
+steps:
+  - locate: role "option" name "Cherry"
+  - focus: role "option" name "Cherry"
+  - activate: role "option" name "Cherry"
+  - verify: role "option" name "Cherry" attribute "aria-selected" is "true"

--- a/usecases/listbox/listbox-single-end.uc.yaml
+++ b/usecases/listbox/listbox-single-end.uc.yaml
@@ -1,0 +1,18 @@
+id: listbox-single-end
+title: "Listbox — End jumps to the last option"
+type: positive
+description: "In a single-select listbox, End moves focus and selection to the last
+  option."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-listbox--single-select-bare&viewMode=story"
+
+expected_result: "After End, Elderberry is selected."
+
+steps:
+  - locate: role "option" name "Apple"
+  - focus: role "option" name "Apple"
+  - keyboard: "End"
+  - verify: role "option" name "Elderberry" attribute "aria-selected" is "true"

--- a/usecases/listbox/listbox-single-first-selected.uc.yaml
+++ b/usecases/listbox/listbox-single-first-selected.uc.yaml
@@ -1,0 +1,16 @@
+id: listbox-single-first-selected
+title: "Listbox — Initial selection is reflected via aria-selected"
+type: positive
+description: 'The option matching the initial value reports aria-selected="true" on first
+  render.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-listbox--single-select-bare&viewMode=story"
+
+expected_result: 'The Apple option reports aria-selected="true".'
+
+steps:
+  - locate: role "option" name "Apple"
+  - verify: role "option" name "Apple" attribute "aria-selected" is "true"

--- a/usecases/listbox/listbox-single-home.uc.yaml
+++ b/usecases/listbox/listbox-single-home.uc.yaml
@@ -1,0 +1,20 @@
+id: listbox-single-home
+title: "Listbox — Home jumps to the first option"
+type: positive
+description: "In a single-select listbox, Home moves focus and selection to the first
+  option."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-listbox--single-select-bare&viewMode=story"
+
+expected_result: "After Home from Elderberry, Apple is selected."
+
+steps:
+  - locate: role "option" name "Apple"
+  - focus: role "option" name "Apple"
+  - keyboard: "End"
+  - verify: role "option" name "Elderberry" attribute "aria-selected" is "true"
+  - keyboard: "Home"
+  - verify: role "option" name "Apple" attribute "aria-selected" is "true"

--- a/usecases/listbox/listbox-single-role.uc.yaml
+++ b/usecases/listbox/listbox-single-role.uc.yaml
@@ -1,0 +1,15 @@
+id: listbox-single-role
+title: "Listbox — Single-select listbox is exposed with an accessible name"
+type: positive
+description: 'The container advertises role="listbox" with the configured label as its
+  accessible name.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-listbox--single-select-bare&viewMode=story"
+
+expected_result: 'A listbox named "Pick a fruit" is present.'
+
+steps:
+  - locate: role "listbox" name "Pick a fruit"

--- a/usecases/menu-button/menu-button-arrow-down-cycles.uc.yaml
+++ b/usecases/menu-button/menu-button-arrow-down-cycles.uc.yaml
@@ -1,0 +1,19 @@
+id: menu-button-arrow-down-cycles
+title: "MenuButton — ArrowDown inside the menu moves focus to the next item"
+type: positive
+description: "When the menu is open, ArrowDown moves focus to the next menuitem."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-menubutton--default&viewMode=story"
+
+expected_result: 'Focus moves from "New document" to "Open…".'
+
+steps:
+  - locate: button "Actions"
+  - focus: button "Actions"
+  - activate: button "Actions"
+  - verify: focus menuitem "New document"
+  - keyboard: "ArrowDown"
+  - verify: focus menuitem "Open…"

--- a/usecases/menu-button/menu-button-arrow-down-opens.uc.yaml
+++ b/usecases/menu-button/menu-button-arrow-down-opens.uc.yaml
@@ -1,0 +1,18 @@
+id: menu-button-arrow-down-opens
+title: "MenuButton — ArrowDown on the trigger opens the menu (first item focused)"
+type: positive
+description: "Per the APG, pressing ArrowDown while the trigger has focus opens the menu
+  and moves focus to the first menuitem."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-menubutton--default&viewMode=story"
+
+expected_result: "The menu opens and the first menuitem has focus."
+
+steps:
+  - locate: button "Actions"
+  - focus: button "Actions"
+  - keyboard: "ArrowDown"
+  - verify: focus menuitem "New document"

--- a/usecases/menu-button/menu-button-arrow-up-opens.uc.yaml
+++ b/usecases/menu-button/menu-button-arrow-up-opens.uc.yaml
@@ -1,0 +1,18 @@
+id: menu-button-arrow-up-opens
+title: "MenuButton — ArrowUp on the trigger opens the menu (last item focused)"
+type: positive
+description: "Per the APG, pressing ArrowUp while the trigger has focus opens the menu and
+  moves focus to the last menuitem."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-menubutton--default&viewMode=story"
+
+expected_result: 'The menu opens and "Export as PDF" (the last item) has focus.'
+
+steps:
+  - locate: button "Actions"
+  - focus: button "Actions"
+  - keyboard: "ArrowUp"
+  - verify: focus menuitem "Export as PDF"

--- a/usecases/menu-button/menu-button-click-item.uc.yaml
+++ b/usecases/menu-button/menu-button-click-item.uc.yaml
@@ -1,0 +1,21 @@
+id: menu-button-click-item
+title: "MenuButton — Activating a menuitem closes the menu"
+type: positive
+description: "A user can activate a menuitem by clicking. The menu closes and focus
+  returns to the trigger."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-menubutton--default&viewMode=story"
+
+expected_result: 'After activating "Save" the menu is closed.'
+
+steps:
+  - locate: button "Actions"
+  - focus: button "Actions"
+  - activate: button "Actions"
+  - locate: menuitem "Save"
+  - focus: menuitem "Save"
+  - activate: menuitem "Save"
+  - verify: button "Actions" attribute "aria-expanded" is "false"

--- a/usecases/menu-button/menu-button-click-opens.uc.yaml
+++ b/usecases/menu-button/menu-button-click-opens.uc.yaml
@@ -1,0 +1,20 @@
+id: menu-button-click-opens
+title: "MenuButton — Activating the trigger opens the menu and focuses the first item"
+type: positive
+description: 'Activating the trigger button sets aria-expanded="true", reveals the menu,
+  and moves focus to the first menuitem.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-menubutton--default&viewMode=story"
+
+expected_result: 'aria-expanded is "true", the menu is visible, and the first menuitem has
+  focus.'
+
+steps:
+  - locate: button "Actions"
+  - focus: button "Actions"
+  - activate: button "Actions"
+  - verify: button "Actions" attribute "aria-expanded" is "true"
+  - verify: focus menuitem "New document"

--- a/usecases/menu-button/menu-button-closed-state.uc.yaml
+++ b/usecases/menu-button/menu-button-closed-state.uc.yaml
@@ -1,0 +1,17 @@
+id: menu-button-closed-state
+title: 'MenuButton — Trigger advertises aria-haspopup and aria-expanded="false"'
+type: positive
+description: 'A closed MenuButton trigger reports aria-haspopup="menu" and
+  aria-expanded="false" so AT can announce it as a button that opens a menu.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-menubutton--default&viewMode=story"
+
+expected_result: 'aria-haspopup is "menu" and aria-expanded is "false".'
+
+steps:
+  - locate: button "Actions"
+  - verify: button "Actions" attribute "aria-haspopup" is "menu"
+  - verify: button "Actions" attribute "aria-expanded" is "false"

--- a/usecases/menu-button/menu-button-enter-activates.uc.yaml
+++ b/usecases/menu-button/menu-button-enter-activates.uc.yaml
@@ -1,0 +1,21 @@
+id: menu-button-enter-activates
+title: "MenuButton — Enter activates the focused menuitem and closes the menu"
+type: positive
+description: "Pressing Enter on a focused menuitem invokes its onSelect handler, closes
+  the menu, and returns focus to the trigger."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-menubutton--default&viewMode=story"
+
+expected_result: "After Enter the menu is closed and focus returns to the trigger."
+
+steps:
+  - locate: button "Actions"
+  - focus: button "Actions"
+  - activate: button "Actions"
+  - verify: focus menuitem "New document"
+  - keyboard: "Enter"
+  - verify: focus button "Actions"
+  - verify: button "Actions" attribute "aria-expanded" is "false"

--- a/usecases/menu-button/menu-button-escape-closes.uc.yaml
+++ b/usecases/menu-button/menu-button-escape-closes.uc.yaml
@@ -1,0 +1,21 @@
+id: menu-button-escape-closes
+title: "MenuButton — Escape closes the menu and returns focus to the trigger"
+type: positive
+description: "Per the APG, pressing Escape while inside an open menu closes it and returns
+  keyboard focus to the trigger button."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-menubutton--default&viewMode=story"
+
+expected_result: 'The menu is removed and focus returns to the "Actions" button.'
+
+steps:
+  - locate: button "Actions"
+  - focus: button "Actions"
+  - activate: button "Actions"
+  - verify: focus menuitem "New document"
+  - keyboard: "Escape"
+  - verify: focus button "Actions"
+  - verify: button "Actions" attribute "aria-expanded" is "false"

--- a/usecases/menu-button/menu-button-home-end.uc.yaml
+++ b/usecases/menu-button/menu-button-home-end.uc.yaml
@@ -1,0 +1,22 @@
+id: menu-button-home-end
+title: "MenuButton — Home and End jump to first and last menuitems"
+type: positive
+description: "When the menu is open, Home jumps focus to the first menuitem and End jumps
+  to the last."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-menubutton--default&viewMode=story"
+
+expected_result: 'End focuses "Export as PDF"; Home returns focus to "New document".'
+
+steps:
+  - locate: button "Actions"
+  - focus: button "Actions"
+  - activate: button "Actions"
+  - verify: focus menuitem "New document"
+  - keyboard: "End"
+  - verify: focus menuitem "Export as PDF"
+  - keyboard: "Home"
+  - verify: focus menuitem "New document"

--- a/usecases/menubar/menubar-arrow-down-opens-submenu.uc.yaml
+++ b/usecases/menubar/menubar-arrow-down-opens-submenu.uc.yaml
@@ -1,0 +1,19 @@
+id: menubar-arrow-down-opens-submenu
+title: "Menubar — ArrowDown opens the submenu with first item focused"
+type: positive
+description: "Pressing ArrowDown on a menubar item opens its submenu and moves focus to
+  the first menuitem inside."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-menubar--default&viewMode=story"
+
+expected_result: 'File menubar item reports aria-expanded="true" and "New" is focused.'
+
+steps:
+  - locate: menuitem "File"
+  - focus: menuitem "File"
+  - keyboard: "ArrowDown"
+  - verify: menuitem "File" attribute "aria-expanded" is "true"
+  - verify: focus menuitem "New"

--- a/usecases/menubar/menubar-arrow-left.uc.yaml
+++ b/usecases/menubar/menubar-arrow-left.uc.yaml
@@ -1,0 +1,18 @@
+id: menubar-arrow-left
+title: "Menubar — ArrowLeft cycles to the previous menubar item (wraps)"
+type: positive
+description: "ArrowLeft moves focus to the previous menubar item; from the first item it
+  wraps to the last."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-menubar--default&viewMode=story"
+
+expected_result: "Focus moves from File to View (wrap)."
+
+steps:
+  - locate: menuitem "File"
+  - focus: menuitem "File"
+  - keyboard: "ArrowLeft"
+  - verify: focus menuitem "View"

--- a/usecases/menubar/menubar-arrow-right.uc.yaml
+++ b/usecases/menubar/menubar-arrow-right.uc.yaml
@@ -1,0 +1,18 @@
+id: menubar-arrow-right
+title: "Menubar — ArrowRight cycles to the next menubar item"
+type: positive
+description: "Pressing ArrowRight while focus is on a menubar item moves focus to the next
+  item."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-menubar--default&viewMode=story"
+
+expected_result: "Focus moves from File to Edit."
+
+steps:
+  - locate: menuitem "File"
+  - focus: menuitem "File"
+  - keyboard: "ArrowRight"
+  - verify: focus menuitem "Edit"

--- a/usecases/menubar/menubar-arrow-up-opens-last.uc.yaml
+++ b/usecases/menubar/menubar-arrow-up-opens-last.uc.yaml
@@ -1,0 +1,18 @@
+id: menubar-arrow-up-opens-last
+title: "Menubar — ArrowUp opens the submenu with last item focused"
+type: positive
+description: "Pressing ArrowUp on a menubar item opens its submenu and moves focus to the
+  last menuitem inside."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-menubar--default&viewMode=story"
+
+expected_result: 'File submenu opens and "Save" (last item) has focus.'
+
+steps:
+  - locate: menuitem "File"
+  - focus: menuitem "File"
+  - keyboard: "ArrowUp"
+  - verify: focus menuitem "Save"

--- a/usecases/menubar/menubar-enter-opens-submenu.uc.yaml
+++ b/usecases/menubar/menubar-enter-opens-submenu.uc.yaml
@@ -1,0 +1,18 @@
+id: menubar-enter-opens-submenu
+title: "Menubar — Enter on a menubar item opens its submenu"
+type: positive
+description: "Pressing Enter on a focused menubar item opens its submenu with focus on the
+  first menuitem."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-menubar--default&viewMode=story"
+
+expected_result: 'Edit submenu opens and "Undo" has focus.'
+
+steps:
+  - locate: menuitem "Edit"
+  - focus: menuitem "Edit"
+  - keyboard: "Enter"
+  - verify: focus menuitem "Undo"

--- a/usecases/menubar/menubar-role-and-orientation.uc.yaml
+++ b/usecases/menubar/menubar-role-and-orientation.uc.yaml
@@ -1,0 +1,16 @@
+id: menubar-role-and-orientation
+title: 'Menubar — Container is exposed with role="menubar" and aria-orientation="horizontal"'
+type: positive
+description: 'The Menubar container advertises role="menubar" with the configured label
+  and aria-orientation="horizontal".'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-menubar--default&viewMode=story"
+
+expected_result: 'A menubar named "Main menu" is present and reports horizontal orientation.'
+
+steps:
+  - locate: role "menubar" name "Main menu"
+  - verify: role "menubar" name "Main menu" attribute "aria-orientation" is "horizontal"

--- a/usecases/menubar/menubar-submenu-arrow-down-cycles.uc.yaml
+++ b/usecases/menubar/menubar-submenu-arrow-down-cycles.uc.yaml
@@ -1,0 +1,19 @@
+id: menubar-submenu-arrow-down-cycles
+title: "Menubar — ArrowDown inside a submenu moves focus to the next menuitem"
+type: positive
+description: "In an open submenu, ArrowDown moves focus to the next menuitem."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-menubar--default&viewMode=story"
+
+expected_result: 'Focus moves from "Undo" to "Redo".'
+
+steps:
+  - locate: menuitem "Edit"
+  - focus: menuitem "Edit"
+  - keyboard: "ArrowDown"
+  - verify: focus menuitem "Undo"
+  - keyboard: "ArrowDown"
+  - verify: focus menuitem "Redo"

--- a/usecases/menubar/menubar-submenu-arrow-right-next-menu.uc.yaml
+++ b/usecases/menubar/menubar-submenu-arrow-right-next-menu.uc.yaml
@@ -1,0 +1,21 @@
+id: menubar-submenu-arrow-right-next-menu
+title: "Menubar — ArrowRight inside a submenu opens the next menubar menu"
+type: positive
+description: "Within an open submenu, ArrowRight closes the current submenu and opens the
+  next menubar menu with focus on its first item."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-menubar--default&viewMode=story"
+
+expected_result: 'After ArrowRight from inside the File submenu, focus is on "Undo" (first
+  item of Edit).'
+
+steps:
+  - locate: menuitem "File"
+  - focus: menuitem "File"
+  - keyboard: "ArrowDown"
+  - verify: focus menuitem "New"
+  - keyboard: "ArrowRight"
+  - verify: focus menuitem "Undo"

--- a/usecases/menubar/menubar-submenu-escape-closes.uc.yaml
+++ b/usecases/menubar/menubar-submenu-escape-closes.uc.yaml
@@ -1,0 +1,21 @@
+id: menubar-submenu-escape-closes
+title: "Menubar — Escape closes the open submenu and returns focus to the menubar"
+type: positive
+description: "Pressing Escape while inside an open submenu closes it and restores focus to
+  the parent menubar item."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-menubar--default&viewMode=story"
+
+expected_result: 'After Escape, focus is on the Edit menubar item with aria-expanded="false".'
+
+steps:
+  - locate: menuitem "Edit"
+  - focus: menuitem "Edit"
+  - keyboard: "ArrowDown"
+  - verify: focus menuitem "Undo"
+  - keyboard: "Escape"
+  - verify: focus menuitem "Edit"
+  - verify: menuitem "Edit" attribute "aria-expanded" is "false"

--- a/usecases/meter/meter-aria-values.uc.yaml
+++ b/usecases/meter/meter-aria-values.uc.yaml
@@ -1,0 +1,18 @@
+id: meter-aria-values
+title: "Meter — Reports aria-valuenow, aria-valuemin, and aria-valuemax"
+type: positive
+description: "The meter advertises its current value via aria-valuenow and the bounds via
+  aria-valuemin/aria-valuemax."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-meter--default&viewMode=story"
+
+expected_result: 'aria-valuenow="72", aria-valuemin="0", aria-valuemax="100".'
+
+steps:
+  - locate: role "meter" name "Disk usage"
+  - verify: role "meter" name "Disk usage" attribute "aria-valuenow" is "72"
+  - verify: role "meter" name "Disk usage" attribute "aria-valuemin" is "0"
+  - verify: role "meter" name "Disk usage" attribute "aria-valuemax" is "100"

--- a/usecases/meter/meter-custom-range.uc.yaml
+++ b/usecases/meter/meter-custom-range.uc.yaml
@@ -1,0 +1,18 @@
+id: meter-custom-range
+title: "Meter — Honors custom minValue and maxValue"
+type: positive
+description: "When configured with custom bounds the meter reports them via
+  aria-valuemin/aria-valuemax."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-meter--with-custom-range&viewMode=story"
+
+expected_result: 'aria-valuemin="0", aria-valuemax="10", aria-valuenow="7".'
+
+steps:
+  - locate: role "meter" name "Satisfaction score"
+  - verify: role "meter" name "Satisfaction score" attribute "aria-valuemin" is "0"
+  - verify: role "meter" name "Satisfaction score" attribute "aria-valuemax" is "10"
+  - verify: role "meter" name "Satisfaction score" attribute "aria-valuenow" is "7"

--- a/usecases/meter/meter-role-and-name.uc.yaml
+++ b/usecases/meter/meter-role-and-name.uc.yaml
@@ -1,0 +1,15 @@
+id: meter-role-and-name
+title: 'Meter — Exposes role="meter" with the configured label'
+type: positive
+description: 'The Meter component is exposed via role="meter" with the supplied label as
+  its accessible name.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-meter--default&viewMode=story"
+
+expected_result: 'A meter named "Disk usage" is present.'
+
+steps:
+  - locate: role "meter" name "Disk usage"

--- a/usecases/modal-dialog/modal-dialog-aria-modal.uc.yaml
+++ b/usecases/modal-dialog/modal-dialog-aria-modal.uc.yaml
@@ -1,0 +1,17 @@
+id: modal-dialog-aria-modal
+title: 'ModalDialog — Reports aria-modal="true" and aria-labelledby on the dialog'
+type: positive
+description: 'The open dialog advertises aria-modal="true" so AT can convey its modal
+  nature, and aria-labelledby references the modal title heading.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-modaldialog--open-by-default-bare&viewMode=story"
+
+expected_result: 'The dialog has aria-modal="true" and aria-labelledby="modal-title".'
+
+steps:
+  - locate: dialog "Modal title"
+  - verify: dialog "Modal title" attribute "aria-modal" is "true"
+  - verify: dialog "Modal title" attribute "aria-labelledby" is "modal-title"

--- a/usecases/modal-dialog/modal-dialog-close-button.uc.yaml
+++ b/usecases/modal-dialog/modal-dialog-close-button.uc.yaml
@@ -1,0 +1,18 @@
+id: modal-dialog-close-button
+title: "ModalDialog — Activating the Close button dismisses the dialog"
+type: positive
+description: "A user can dismiss the modal by activating its Close button. The dialog is
+  removed from the accessibility tree."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-modaldialog--open-by-default-bare&viewMode=story"
+
+expected_result: "After activation the dialog is no longer present."
+
+steps:
+  - locate: button "Close dialog"
+  - focus: button "Close dialog"
+  - activate: button "Close dialog"
+  - verify: hidden heading "Modal title"

--- a/usecases/modal-dialog/modal-dialog-escape-closes.uc.yaml
+++ b/usecases/modal-dialog/modal-dialog-escape-closes.uc.yaml
@@ -1,0 +1,16 @@
+id: modal-dialog-escape-closes
+title: "ModalDialog — Escape closes the dialog"
+type: positive
+description: "Per the APG, pressing Escape while a modal dialog is open dismisses it."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-modaldialog--open-by-default-bare&viewMode=story"
+
+expected_result: "After Escape the dialog is no longer present."
+
+steps:
+  - locate: dialog "Modal title"
+  - keyboard: "Escape"
+  - verify: hidden heading "Modal title"

--- a/usecases/modal-dialog/modal-dialog-focus-restores.uc.yaml
+++ b/usecases/modal-dialog/modal-dialog-focus-restores.uc.yaml
@@ -1,0 +1,20 @@
+id: modal-dialog-focus-restores
+title: "ModalDialog — Closing returns focus to the invoking element"
+type: positive
+description: "After dismissing the modal, focus is returned to the element that opened
+  it."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-modaldialog--default-bare&viewMode=story"
+
+expected_result: 'Focus is back on the "Open modal" trigger after the dialog closes.'
+
+steps:
+  - locate: button "Open modal"
+  - focus: button "Open modal"
+  - activate: button "Open modal"
+  - verify: visible heading "Modal title"
+  - keyboard: "Escape"
+  - verify: focus button "Open modal"

--- a/usecases/modal-dialog/modal-dialog-trigger-opens.uc.yaml
+++ b/usecases/modal-dialog/modal-dialog-trigger-opens.uc.yaml
@@ -1,0 +1,18 @@
+id: modal-dialog-trigger-opens
+title: "ModalDialog — Activating the trigger opens the modal"
+type: positive
+description: 'Activating the trigger button mounts a dialog with role="dialog" and
+  aria-modal="true".'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-modaldialog--default-bare&viewMode=story"
+
+expected_result: 'A dialog named "Modal title" is present after activation.'
+
+steps:
+  - locate: button "Open modal"
+  - focus: button "Open modal"
+  - activate: button "Open modal"
+  - verify: visible heading "Modal title"

--- a/usecases/progressbar/progressbar-determinate-role.uc.yaml
+++ b/usecases/progressbar/progressbar-determinate-role.uc.yaml
@@ -1,0 +1,15 @@
+id: progressbar-determinate-role
+title: 'Progressbar — Determinate progressbar exposes role="progressbar" with name'
+type: positive
+description: 'A determinate progressbar advertises role="progressbar" with the configured
+  label as its accessible name.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-progressbar--determinate&viewMode=story"
+
+expected_result: 'A progressbar named "Upload progress" is present.'
+
+steps:
+  - locate: role "progressbar" name "Upload progress"

--- a/usecases/progressbar/progressbar-determinate-values.uc.yaml
+++ b/usecases/progressbar/progressbar-determinate-values.uc.yaml
@@ -1,0 +1,18 @@
+id: progressbar-determinate-values
+title: "Progressbar — Reports aria-valuenow/min/max for determinate progress"
+type: positive
+description: "The determinate progressbar advertises aria-valuenow, aria-valuemin, and
+  aria-valuemax so AT can announce numeric progress."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-progressbar--determinate&viewMode=story"
+
+expected_result: 'aria-valuenow="65", aria-valuemin="0", aria-valuemax="100".'
+
+steps:
+  - locate: role "progressbar" name "Upload progress"
+  - verify: role "progressbar" name "Upload progress" attribute "aria-valuenow" is "65"
+  - verify: role "progressbar" name "Upload progress" attribute "aria-valuemin" is "0"
+  - verify: role "progressbar" name "Upload progress" attribute "aria-valuemax" is "100"

--- a/usecases/progressbar/progressbar-with-valuetext.uc.yaml
+++ b/usecases/progressbar/progressbar-with-valuetext.uc.yaml
@@ -1,0 +1,16 @@
+id: progressbar-with-valuetext
+title: "Progressbar — aria-valuetext overrides the numeric announcement"
+type: positive
+description: "When valueText is provided, the progressbar exposes aria-valuetext for AT to
+  announce a richer string than the raw number."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-progressbar--with-value-text&viewMode=story"
+
+expected_result: 'aria-valuetext is "3 of 10 steps".'
+
+steps:
+  - locate: role "progressbar" name "Steps completed"
+  - verify: role "progressbar" name "Steps completed" attribute "aria-valuetext" is "3 of 10 steps"

--- a/usecases/radio-group/radio-group-arrow-down.uc.yaml
+++ b/usecases/radio-group/radio-group-arrow-down.uc.yaml
@@ -1,0 +1,19 @@
+id: radio-group-arrow-down
+title: "RadioGroup — ArrowDown moves selection to the next radio"
+type: positive
+description: "In a radiogroup, ArrowDown moves focus and selection from the current radio
+  to the next."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-radiogroup--default-bare&viewMode=story"
+
+expected_result: "After ArrowDown the SMS radio is selected."
+
+steps:
+  - locate: radio "Email"
+  - focus: radio "Email"
+  - keyboard: "ArrowDown"
+  - verify: radio "SMS" attribute "aria-checked" is "true"
+  - verify: radio "Email" attribute "aria-checked" is "false"

--- a/usecases/radio-group/radio-group-arrow-up-wraps.uc.yaml
+++ b/usecases/radio-group/radio-group-arrow-up-wraps.uc.yaml
@@ -1,0 +1,18 @@
+id: radio-group-arrow-up-wraps
+title: "RadioGroup — ArrowUp wraps from the first radio to the last"
+type: positive
+description: "When focus is on the first radio, ArrowUp wraps focus and selection to the
+  last radio."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-radiogroup--default-bare&viewMode=story"
+
+expected_result: 'After ArrowUp the "Push notification" radio is selected.'
+
+steps:
+  - locate: radio "Email"
+  - focus: radio "Email"
+  - keyboard: "ArrowUp"
+  - verify: radio "Push notification" attribute "aria-checked" is "true"

--- a/usecases/radio-group/radio-group-click-selects.uc.yaml
+++ b/usecases/radio-group/radio-group-click-selects.uc.yaml
@@ -1,0 +1,18 @@
+id: radio-group-click-selects
+title: "RadioGroup — Activating a radio selects it"
+type: positive
+description: "Clicking on a radio selects it and clears the previous selection."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-radiogroup--default-bare&viewMode=story"
+
+expected_result: "After activation SMS is selected and Email is no longer selected."
+
+steps:
+  - locate: radio "SMS"
+  - focus: radio "SMS"
+  - activate: radio "SMS"
+  - verify: radio "SMS" attribute "aria-checked" is "true"
+  - verify: radio "Email" attribute "aria-checked" is "false"

--- a/usecases/radio-group/radio-group-first-checked.uc.yaml
+++ b/usecases/radio-group/radio-group-first-checked.uc.yaml
@@ -1,0 +1,16 @@
+id: radio-group-first-checked
+title: "RadioGroup — Initial selection is reflected via aria-checked"
+type: positive
+description: "When no value prop is supplied, the first radio option is selected by
+  default."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-radiogroup--default-bare&viewMode=story"
+
+expected_result: 'The "Email" radio reports aria-checked="true".'
+
+steps:
+  - locate: radio "Email"
+  - verify: radio "Email" attribute "aria-checked" is "true"

--- a/usecases/radio-group/radio-group-home-end.uc.yaml
+++ b/usecases/radio-group/radio-group-home-end.uc.yaml
@@ -1,0 +1,20 @@
+id: radio-group-home-end
+title: "RadioGroup — Home and End jump to first and last radios"
+type: positive
+description: "Home moves focus and selection to the first radio; End moves them to the
+  last."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-radiogroup--default-bare&viewMode=story"
+
+expected_result: 'End selects "Push notification"; Home returns selection to "Email".'
+
+steps:
+  - locate: radio "Email"
+  - focus: radio "Email"
+  - keyboard: "End"
+  - verify: radio "Push notification" attribute "aria-checked" is "true"
+  - keyboard: "Home"
+  - verify: radio "Email" attribute "aria-checked" is "true"

--- a/usecases/radio-group/radio-group-role.uc.yaml
+++ b/usecases/radio-group/radio-group-role.uc.yaml
@@ -1,0 +1,15 @@
+id: radio-group-role
+title: 'RadioGroup — Container is exposed via role="radiogroup" with a name'
+type: positive
+description: 'The RadioGroup container advertises role="radiogroup" with the supplied
+  label as its accessible name.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-radiogroup--default-bare&viewMode=story"
+
+expected_result: 'A radiogroup named "Preferred contact method" is present.'
+
+steps:
+  - locate: role "radiogroup" name "Preferred contact method"

--- a/usecases/slider-multi-thumb/slider-multi-thumb-high-arrow-left.uc.yaml
+++ b/usecases/slider-multi-thumb/slider-multi-thumb-high-arrow-left.uc.yaml
@@ -1,0 +1,18 @@
+id: slider-multi-thumb-high-arrow-left
+title: "SliderMultiThumb — ArrowLeft on the high thumb decrements it"
+type: positive
+description: "When focus is on the high thumb, ArrowLeft decrements aria-valuenow by the
+  configured step."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-slidermultithumb--price-range-bare&viewMode=story"
+
+expected_result: 'High aria-valuenow becomes "79" after one ArrowLeft.'
+
+steps:
+  - locate: role "slider" name "Maximum price"
+  - focus: role "slider" name "Maximum price"
+  - keyboard: "ArrowLeft"
+  - verify: role "slider" name "Maximum price" attribute "aria-valuenow" is "79"

--- a/usecases/slider-multi-thumb/slider-multi-thumb-low-arrow-right.uc.yaml
+++ b/usecases/slider-multi-thumb/slider-multi-thumb-low-arrow-right.uc.yaml
@@ -1,0 +1,18 @@
+id: slider-multi-thumb-low-arrow-right
+title: "SliderMultiThumb — ArrowRight on the low thumb increments it"
+type: positive
+description: "When focus is on the low thumb, ArrowRight increments aria-valuenow by the
+  configured step."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-slidermultithumb--price-range-bare&viewMode=story"
+
+expected_result: 'Low aria-valuenow becomes "21" after one ArrowRight.'
+
+steps:
+  - locate: role "slider" name "Minimum price"
+  - focus: role "slider" name "Minimum price"
+  - keyboard: "ArrowRight"
+  - verify: role "slider" name "Minimum price" attribute "aria-valuenow" is "21"

--- a/usecases/slider-multi-thumb/slider-multi-thumb-low-constrained-by-high.uc.yaml
+++ b/usecases/slider-multi-thumb/slider-multi-thumb-low-constrained-by-high.uc.yaml
@@ -1,0 +1,18 @@
+id: slider-multi-thumb-low-constrained-by-high
+title: "SliderMultiThumb — The low thumb is bounded above by the high thumb"
+type: positive
+description: "The low thumb advertises aria-valuemax equal to the current high value, and
+  the high thumb advertises aria-valuemin equal to the current low value."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-slidermultithumb--price-range-bare&viewMode=story"
+
+expected_result: 'Low aria-valuemax is "80" and high aria-valuemin is "20".'
+
+steps:
+  - locate: role "slider" name "Minimum price"
+  - verify: role "slider" name "Minimum price" attribute "aria-valuemax" is "80"
+  - locate: role "slider" name "Maximum price"
+  - verify: role "slider" name "Maximum price" attribute "aria-valuemin" is "20"

--- a/usecases/slider-multi-thumb/slider-multi-thumb-low-end-clamps.uc.yaml
+++ b/usecases/slider-multi-thumb/slider-multi-thumb-low-end-clamps.uc.yaml
@@ -1,0 +1,18 @@
+id: slider-multi-thumb-low-end-clamps
+title: "SliderMultiThumb — End on the low thumb clamps to the high thumb value"
+type: positive
+description: "Pressing End on the low thumb does not jump to the absolute maximum; it is
+  clamped to the current high thumb value."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-slidermultithumb--price-range-bare&viewMode=story"
+
+expected_result: 'Low aria-valuenow becomes "80" (the high value), not "100".'
+
+steps:
+  - locate: role "slider" name "Minimum price"
+  - focus: role "slider" name "Minimum price"
+  - keyboard: "End"
+  - verify: role "slider" name "Minimum price" attribute "aria-valuenow" is "80"

--- a/usecases/slider-multi-thumb/slider-multi-thumb-two-distinct-thumbs.uc.yaml
+++ b/usecases/slider-multi-thumb/slider-multi-thumb-two-distinct-thumbs.uc.yaml
@@ -1,0 +1,16 @@
+id: slider-multi-thumb-two-distinct-thumbs
+title: "SliderMultiThumb — Two sliders with distinct accessible names are exposed"
+type: positive
+description: 'A multi-thumb slider exposes two role="slider" elements, each with a unique
+  aria-label so AT can address them individually.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-slidermultithumb--price-range-bare&viewMode=story"
+
+expected_result: 'Both "Minimum price" and "Maximum price" sliders are present.'
+
+steps:
+  - locate: role "slider" name "Minimum price"
+  - locate: role "slider" name "Maximum price"

--- a/usecases/slider/slider-arrow-left-decrements.uc.yaml
+++ b/usecases/slider/slider-arrow-left-decrements.uc.yaml
@@ -1,0 +1,18 @@
+id: slider-arrow-left-decrements
+title: "Slider — ArrowLeft decrements the value by step"
+type: positive
+description: "Pressing ArrowLeft while the slider thumb has focus decrements
+  aria-valuenow by the configured step."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-slider--horizontal-bare&viewMode=story"
+
+expected_result: 'aria-valuenow becomes "49" after one ArrowLeft from "50".'
+
+steps:
+  - locate: role "slider" name "Volume"
+  - focus: role "slider" name "Volume"
+  - keyboard: "ArrowLeft"
+  - verify: role "slider" name "Volume" attribute "aria-valuenow" is "49"

--- a/usecases/slider/slider-arrow-right-increments.uc.yaml
+++ b/usecases/slider/slider-arrow-right-increments.uc.yaml
@@ -1,0 +1,19 @@
+id: slider-arrow-right-increments
+title: "Slider — ArrowRight increments the value by step"
+type: positive
+description: "Pressing ArrowRight while the slider thumb has focus increments
+  aria-valuenow by the configured step."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-slider--horizontal-bare&viewMode=story"
+
+expected_result: 'aria-valuenow becomes "51" after one ArrowRight from "50".'
+
+steps:
+  - locate: role "slider" name "Volume"
+  - focus: role "slider" name "Volume"
+  - verify: role "slider" name "Volume" attribute "aria-valuenow" is "50"
+  - keyboard: "ArrowRight"
+  - verify: role "slider" name "Volume" attribute "aria-valuenow" is "51"

--- a/usecases/slider/slider-end-jumps-max.uc.yaml
+++ b/usecases/slider/slider-end-jumps-max.uc.yaml
@@ -1,0 +1,17 @@
+id: slider-end-jumps-max
+title: "Slider — End sets the value to aria-valuemax"
+type: positive
+description: "Pressing End moves the slider value to its maximum (aria-valuemax)."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-slider--horizontal-bare&viewMode=story"
+
+expected_result: 'aria-valuenow becomes "100" after End.'
+
+steps:
+  - locate: role "slider" name "Volume"
+  - focus: role "slider" name "Volume"
+  - keyboard: "End"
+  - verify: role "slider" name "Volume" attribute "aria-valuenow" is "100"

--- a/usecases/slider/slider-home-jumps-min.uc.yaml
+++ b/usecases/slider/slider-home-jumps-min.uc.yaml
@@ -1,0 +1,17 @@
+id: slider-home-jumps-min
+title: "Slider — Home sets the value to aria-valuemin"
+type: positive
+description: "Pressing Home moves the slider value to its minimum (aria-valuemin)."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-slider--horizontal-bare&viewMode=story"
+
+expected_result: 'aria-valuenow becomes "0" after Home.'
+
+steps:
+  - locate: role "slider" name "Volume"
+  - focus: role "slider" name "Volume"
+  - keyboard: "Home"
+  - verify: role "slider" name "Volume" attribute "aria-valuenow" is "0"

--- a/usecases/slider/slider-pagedown-large-step.uc.yaml
+++ b/usecases/slider/slider-pagedown-large-step.uc.yaml
@@ -1,0 +1,17 @@
+id: slider-pagedown-large-step
+title: "Slider — PageDown decrements by 10× step"
+type: positive
+description: "PageDown moves the slider value backward by 10 × step."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-slider--horizontal-bare&viewMode=story"
+
+expected_result: 'aria-valuenow becomes "40" after PageDown from "50".'
+
+steps:
+  - locate: role "slider" name "Volume"
+  - focus: role "slider" name "Volume"
+  - keyboard: "PageDown"
+  - verify: role "slider" name "Volume" attribute "aria-valuenow" is "40"

--- a/usecases/slider/slider-pageup-large-step.uc.yaml
+++ b/usecases/slider/slider-pageup-large-step.uc.yaml
@@ -1,0 +1,18 @@
+id: slider-pageup-large-step
+title: "Slider — PageUp increments by 10× step"
+type: positive
+description: "PageUp moves the slider value forward by 10 × step for a coarser-grained
+  adjustment."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-slider--horizontal-bare&viewMode=story"
+
+expected_result: 'aria-valuenow becomes "60" after PageUp from "50".'
+
+steps:
+  - locate: role "slider" name "Volume"
+  - focus: role "slider" name "Volume"
+  - keyboard: "PageUp"
+  - verify: role "slider" name "Volume" attribute "aria-valuenow" is "60"

--- a/usecases/slider/slider-role-and-name.uc.yaml
+++ b/usecases/slider/slider-role-and-name.uc.yaml
@@ -1,0 +1,16 @@
+id: slider-role-and-name
+title: 'Slider — Exposes role="slider" with an accessible name'
+type: positive
+description: 'The slider thumb advertises role="slider" with the configured aria-label as
+  its accessible name.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-slider--horizontal-bare&viewMode=story"
+
+expected_result: 'A slider named "Volume" is present.'
+
+steps:
+  - locate: role "slider" name "Volume"
+  - verify: role "slider" name "Volume" attribute "aria-orientation" is "horizontal"

--- a/usecases/slider/slider-vertical-arrow-up.uc.yaml
+++ b/usecases/slider/slider-vertical-arrow-up.uc.yaml
@@ -1,0 +1,18 @@
+id: slider-vertical-arrow-up
+title: "Slider — ArrowUp increments a vertical slider"
+type: positive
+description: "On a vertical slider, ArrowUp increments aria-valuenow by the configured
+  step (here step=5)."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-slider--vertical-bare&viewMode=story"
+
+expected_result: 'aria-valuenow becomes "30" after ArrowUp from "25" (step=5).'
+
+steps:
+  - locate: role "slider" name "Volume"
+  - focus: role "slider" name "Volume"
+  - keyboard: "ArrowUp"
+  - verify: role "slider" name "Volume" attribute "aria-valuenow" is "30"

--- a/usecases/slider/slider-vertical-orientation.uc.yaml
+++ b/usecases/slider/slider-vertical-orientation.uc.yaml
@@ -1,0 +1,16 @@
+id: slider-vertical-orientation
+title: 'Slider — Vertical slider reports aria-orientation="vertical"'
+type: positive
+description: 'When configured vertically, the slider advertises
+  aria-orientation="vertical" so AT can convey its axis.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-slider--vertical-bare&viewMode=story"
+
+expected_result: 'aria-orientation is "vertical".'
+
+steps:
+  - locate: role "slider" name "Volume"
+  - verify: role "slider" name "Volume" attribute "aria-orientation" is "vertical"

--- a/usecases/spinbutton/spinbutton-arrow-down.uc.yaml
+++ b/usecases/spinbutton/spinbutton-arrow-down.uc.yaml
@@ -1,0 +1,18 @@
+id: spinbutton-arrow-down
+title: "Spinbutton — ArrowDown decrements by step"
+type: positive
+description: "Pressing ArrowDown while the spinbutton has focus decrements aria-valuenow
+  by the configured step."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-spinbutton--default-bare&viewMode=story"
+
+expected_result: 'aria-valuenow becomes "4" after one ArrowDown from "5".'
+
+steps:
+  - locate: role "spinbutton" name "Quantity"
+  - focus: role "spinbutton" name "Quantity"
+  - keyboard: "ArrowDown"
+  - verify: role "spinbutton" name "Quantity" attribute "aria-valuenow" is "4"

--- a/usecases/spinbutton/spinbutton-arrow-up.uc.yaml
+++ b/usecases/spinbutton/spinbutton-arrow-up.uc.yaml
@@ -1,0 +1,18 @@
+id: spinbutton-arrow-up
+title: "Spinbutton — ArrowUp increments by step"
+type: positive
+description: "Pressing ArrowUp while the spinbutton has focus increments aria-valuenow by
+  the configured step."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-spinbutton--default-bare&viewMode=story"
+
+expected_result: 'aria-valuenow becomes "6" after one ArrowUp from "5".'
+
+steps:
+  - locate: role "spinbutton" name "Quantity"
+  - focus: role "spinbutton" name "Quantity"
+  - keyboard: "ArrowUp"
+  - verify: role "spinbutton" name "Quantity" attribute "aria-valuenow" is "6"

--- a/usecases/spinbutton/spinbutton-decrease-button.uc.yaml
+++ b/usecases/spinbutton/spinbutton-decrease-button.uc.yaml
@@ -1,0 +1,18 @@
+id: spinbutton-decrease-button
+title: "Spinbutton — Activating the Decrease button reduces the value"
+type: positive
+description: "Activating the visible Decrease button decrements the spinbutton value by
+  step."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-spinbutton--default-bare&viewMode=story"
+
+expected_result: 'aria-valuenow becomes "4" after activating the Decrease button.'
+
+steps:
+  - locate: button "Decrease value"
+  - focus: button "Decrease value"
+  - activate: button "Decrease value"
+  - verify: role "spinbutton" name "Quantity" attribute "aria-valuenow" is "4"

--- a/usecases/spinbutton/spinbutton-home-end.uc.yaml
+++ b/usecases/spinbutton/spinbutton-home-end.uc.yaml
@@ -1,0 +1,19 @@
+id: spinbutton-home-end
+title: "Spinbutton — Home and End jump to min and max"
+type: positive
+description: "Home jumps the value to aria-valuemin; End jumps to aria-valuemax."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-spinbutton--default-bare&viewMode=story"
+
+expected_result: 'After End the value is "10"; after Home it is "0".'
+
+steps:
+  - locate: role "spinbutton" name "Quantity"
+  - focus: role "spinbutton" name "Quantity"
+  - keyboard: "End"
+  - verify: role "spinbutton" name "Quantity" attribute "aria-valuenow" is "10"
+  - keyboard: "Home"
+  - verify: role "spinbutton" name "Quantity" attribute "aria-valuenow" is "0"

--- a/usecases/spinbutton/spinbutton-increase-button.uc.yaml
+++ b/usecases/spinbutton/spinbutton-increase-button.uc.yaml
@@ -1,0 +1,18 @@
+id: spinbutton-increase-button
+title: "Spinbutton — Activating the Increase button bumps the value"
+type: positive
+description: "Activating the visible Increase button increments the spinbutton value by
+  step."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-spinbutton--default-bare&viewMode=story"
+
+expected_result: 'aria-valuenow becomes "6" after activating the Increase button.'
+
+steps:
+  - locate: button "Increase value"
+  - focus: button "Increase value"
+  - activate: button "Increase value"
+  - verify: role "spinbutton" name "Quantity" attribute "aria-valuenow" is "6"

--- a/usecases/spinbutton/spinbutton-pageup-pagedown.uc.yaml
+++ b/usecases/spinbutton/spinbutton-pageup-pagedown.uc.yaml
@@ -1,0 +1,21 @@
+id: spinbutton-pageup-pagedown
+title: "Spinbutton — PageUp and PageDown adjust by 10× step"
+type: positive
+description: "PageUp/PageDown change the value by 10 × step for coarser-grained
+  adjustments."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+  - "Uses the LargeRange story with step=10 and initialValue=100"
+
+start_location: "http://localhost:6006/iframe.html?id=components-spinbutton--large-range-bare&viewMode=story"
+
+expected_result: 'PageUp moves "100" to "200"; PageDown returns to "100".'
+
+steps:
+  - locate: role "spinbutton" name "Amount"
+  - focus: role "spinbutton" name "Amount"
+  - keyboard: "PageUp"
+  - verify: role "spinbutton" name "Amount" attribute "aria-valuenow" is "200"
+  - keyboard: "PageDown"
+  - verify: role "spinbutton" name "Amount" attribute "aria-valuenow" is "100"

--- a/usecases/spinbutton/spinbutton-role-and-name.uc.yaml
+++ b/usecases/spinbutton/spinbutton-role-and-name.uc.yaml
@@ -1,0 +1,18 @@
+id: spinbutton-role-and-name
+title: 'Spinbutton — Exposes role="spinbutton" with an accessible name'
+type: positive
+description: 'The spinbutton input advertises role="spinbutton" with the configured
+  aria-label as its accessible name.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-spinbutton--default-bare&viewMode=story"
+
+expected_result: 'A spinbutton named "Quantity" is present and reports its current value.'
+
+steps:
+  - locate: role "spinbutton" name "Quantity"
+  - verify: role "spinbutton" name "Quantity" attribute "aria-valuenow" is "5"
+  - verify: role "spinbutton" name "Quantity" attribute "aria-valuemin" is "0"
+  - verify: role "spinbutton" name "Quantity" attribute "aria-valuemax" is "10"

--- a/usecases/switch/switch-click-toggles.uc.yaml
+++ b/usecases/switch/switch-click-toggles.uc.yaml
@@ -1,0 +1,18 @@
+id: switch-click-toggles
+title: "Switch — Activating the switch flips aria-checked"
+type: positive
+description: 'Clicking or activating the switch toggles aria-checked between "true" and
+  "false".'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-switch--off-bare&viewMode=story"
+
+expected_result: 'aria-checked becomes "true" after activation.'
+
+steps:
+  - locate: role "switch" name "Enable dark mode"
+  - focus: role "switch" name "Enable dark mode"
+  - activate: role "switch" name "Enable dark mode"
+  - verify: role "switch" name "Enable dark mode" attribute "aria-checked" is "true"

--- a/usecases/switch/switch-enter-toggles.uc.yaml
+++ b/usecases/switch/switch-enter-toggles.uc.yaml
@@ -1,0 +1,17 @@
+id: switch-enter-toggles
+title: "Switch — Enter toggles the switch state"
+type: positive
+description: "Pressing Enter while the switch has focus toggles aria-checked."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-switch--off-bare&viewMode=story"
+
+expected_result: 'aria-checked becomes "true" after Enter.'
+
+steps:
+  - locate: role "switch" name "Enable dark mode"
+  - focus: role "switch" name "Enable dark mode"
+  - keyboard: "Enter"
+  - verify: role "switch" name "Enable dark mode" attribute "aria-checked" is "true"

--- a/usecases/switch/switch-off-starts-unchecked.uc.yaml
+++ b/usecases/switch/switch-off-starts-unchecked.uc.yaml
@@ -1,0 +1,16 @@
+id: switch-off-starts-unchecked
+title: 'Switch — A switch initialized off reports aria-checked="false"'
+type: positive
+description: 'When initialChecked is false, the switch advertises aria-checked="false" on
+  first render.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-switch--off-bare&viewMode=story"
+
+expected_result: 'aria-checked is "false".'
+
+steps:
+  - locate: role "switch" name "Enable dark mode"
+  - verify: role "switch" name "Enable dark mode" attribute "aria-checked" is "false"

--- a/usecases/switch/switch-on-starts-checked.uc.yaml
+++ b/usecases/switch/switch-on-starts-checked.uc.yaml
@@ -1,0 +1,16 @@
+id: switch-on-starts-checked
+title: 'Switch — A switch initialized on reports aria-checked="true"'
+type: positive
+description: 'When initialChecked is true, the switch advertises aria-checked="true" on
+  first render.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-switch--on-bare&viewMode=story"
+
+expected_result: 'aria-checked is "true".'
+
+steps:
+  - locate: role "switch" name "Enable notifications"
+  - verify: role "switch" name "Enable notifications" attribute "aria-checked" is "true"

--- a/usecases/switch/switch-space-toggles.uc.yaml
+++ b/usecases/switch/switch-space-toggles.uc.yaml
@@ -1,0 +1,17 @@
+id: switch-space-toggles
+title: "Switch — Space toggles the switch state"
+type: positive
+description: "Pressing Space while the switch has focus toggles aria-checked."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-switch--off-bare&viewMode=story"
+
+expected_result: 'aria-checked becomes "true" after Space.'
+
+steps:
+  - locate: role "switch" name "Enable dark mode"
+  - focus: role "switch" name "Enable dark mode"
+  - keyboard: "Space"
+  - verify: role "switch" name "Enable dark mode" attribute "aria-checked" is "true"

--- a/usecases/tabs/tabs-arrow-left-wraps.uc.yaml
+++ b/usecases/tabs/tabs-arrow-left-wraps.uc.yaml
@@ -1,0 +1,18 @@
+id: tabs-arrow-left-wraps
+title: "Tabs — ArrowLeft wraps from the first tab to the last"
+type: positive
+description: "ArrowLeft on the first tab wraps focus and selection to the last tab."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-tabs--horizontal-bare&viewMode=story"
+
+expected_result: "After ArrowLeft from Overview, FAQ is focused and selected."
+
+steps:
+  - locate: tab "Overview"
+  - focus: tab "Overview"
+  - keyboard: "ArrowLeft"
+  - verify: focus tab "FAQ"
+  - verify: tab "FAQ" attribute "aria-selected" is "true"

--- a/usecases/tabs/tabs-arrow-right-selects.uc.yaml
+++ b/usecases/tabs/tabs-arrow-right-selects.uc.yaml
@@ -1,0 +1,19 @@
+id: tabs-arrow-right-selects
+title: "Tabs — ArrowRight moves focus and selection (automatic activation)"
+type: positive
+description: "In automatic activation mode, ArrowRight moves focus to the next tab and
+  also activates it."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-tabs--horizontal-bare&viewMode=story"
+
+expected_result: "After ArrowRight from Overview, Pricing is selected."
+
+steps:
+  - locate: tab "Overview"
+  - focus: tab "Overview"
+  - keyboard: "ArrowRight"
+  - verify: focus tab "Pricing"
+  - verify: tab "Pricing" attribute "aria-selected" is "true"

--- a/usecases/tabs/tabs-click-selects.uc.yaml
+++ b/usecases/tabs/tabs-click-selects.uc.yaml
@@ -1,0 +1,18 @@
+id: tabs-click-selects
+title: "Tabs — Activating a tab selects it"
+type: positive
+description: "Clicking on a tab selects it; the previous tab is deselected."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-tabs--horizontal-bare&viewMode=story"
+
+expected_result: "After activating Pricing, that tab is selected."
+
+steps:
+  - locate: tab "Pricing"
+  - focus: tab "Pricing"
+  - activate: tab "Pricing"
+  - verify: tab "Pricing" attribute "aria-selected" is "true"
+  - verify: tab "Overview" attribute "aria-selected" is "false"

--- a/usecases/tabs/tabs-first-selected.uc.yaml
+++ b/usecases/tabs/tabs-first-selected.uc.yaml
@@ -1,0 +1,17 @@
+id: tabs-first-selected
+title: "Tabs — The first tab is selected by default"
+type: positive
+description: 'Without an explicit defaultIndex the first tab is selected
+  (aria-selected="true").'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-tabs--horizontal-bare&viewMode=story"
+
+expected_result: 'The Overview tab reports aria-selected="true".'
+
+steps:
+  - locate: tab "Overview"
+  - verify: tab "Overview" attribute "aria-selected" is "true"
+  - verify: tab "Pricing" attribute "aria-selected" is "false"

--- a/usecases/tabs/tabs-home-end.uc.yaml
+++ b/usecases/tabs/tabs-home-end.uc.yaml
@@ -1,0 +1,20 @@
+id: tabs-home-end
+title: "Tabs — Home and End jump to the first and last tabs"
+type: positive
+description: "Home moves focus and selection to the first tab; End moves them to the
+  last."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-tabs--horizontal-bare&viewMode=story"
+
+expected_result: "End selects FAQ; Home returns selection to Overview."
+
+steps:
+  - locate: tab "Overview"
+  - focus: tab "Overview"
+  - keyboard: "End"
+  - verify: tab "FAQ" attribute "aria-selected" is "true"
+  - keyboard: "Home"
+  - verify: tab "Overview" attribute "aria-selected" is "true"

--- a/usecases/tabs/tabs-manual-arrow-no-select.uc.yaml
+++ b/usecases/tabs/tabs-manual-arrow-no-select.uc.yaml
@@ -1,0 +1,20 @@
+id: tabs-manual-arrow-no-select
+title: "Tabs — In manual mode, ArrowRight moves focus but does not select"
+type: positive
+description: 'When activation="manual", ArrowRight moves focus to the next tab but the
+  selection stays on the previously activated tab until Enter or Space.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-tabs--manual-activation-bare&viewMode=story"
+
+expected_result: "Focus moves to Pricing but Overview remains selected."
+
+steps:
+  - locate: tab "Overview"
+  - focus: tab "Overview"
+  - keyboard: "ArrowRight"
+  - verify: focus tab "Pricing"
+  - verify: tab "Overview" attribute "aria-selected" is "true"
+  - verify: tab "Pricing" attribute "aria-selected" is "false"

--- a/usecases/tabs/tabs-manual-enter-activates.uc.yaml
+++ b/usecases/tabs/tabs-manual-enter-activates.uc.yaml
@@ -1,0 +1,18 @@
+id: tabs-manual-enter-activates
+title: "Tabs — In manual mode, Enter activates the focused tab"
+type: positive
+description: "In manual activation, pressing Enter on the focused tab activates it."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-tabs--manual-activation-bare&viewMode=story"
+
+expected_result: "After ArrowRight + Enter, Pricing is selected."
+
+steps:
+  - locate: tab "Overview"
+  - focus: tab "Overview"
+  - keyboard: "ArrowRight"
+  - keyboard: "Enter"
+  - verify: tab "Pricing" attribute "aria-selected" is "true"

--- a/usecases/tabs/tabs-tablist-role.uc.yaml
+++ b/usecases/tabs/tabs-tablist-role.uc.yaml
@@ -1,0 +1,18 @@
+id: tabs-tablist-role
+title: 'Tabs — Container is exposed via role="tablist" with horizontal orientation'
+type: positive
+description: 'The tablist element advertises role="tablist" and aria-orientation matching
+  the configured orientation.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-tabs--horizontal-bare&viewMode=story"
+
+expected_result: 'A tablist with aria-orientation="horizontal" contains "Overview", "Pricing",
+  and "FAQ" tabs.'
+
+steps:
+  - locate: tab "Overview"
+  - locate: tab "Pricing"
+  - locate: tab "FAQ"

--- a/usecases/tabs/tabs-tabpanel-controlled.uc.yaml
+++ b/usecases/tabs/tabs-tabpanel-controlled.uc.yaml
@@ -1,0 +1,20 @@
+id: tabs-tabpanel-controlled
+title: "Tabs — Each tab references its panel via aria-controls"
+type: positive
+description: "Every tab advertises aria-controls pointing at the id of its associated
+  tabpanel."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-tabs--horizontal-bare&viewMode=story"
+
+expected_result: "Each tab has aria-controls referencing its panel."
+
+steps:
+  - locate: tab "Overview"
+  - verify: tab "Overview" attribute "aria-controls" is "h-panel-overview"
+  - locate: tab "Pricing"
+  - verify: tab "Pricing" attribute "aria-controls" is "h-panel-pricing"
+  - locate: tab "FAQ"
+  - verify: tab "FAQ" attribute "aria-controls" is "h-panel-faq"

--- a/usecases/tabs/tabs-vertical-arrow-down.uc.yaml
+++ b/usecases/tabs/tabs-vertical-arrow-down.uc.yaml
@@ -1,0 +1,18 @@
+id: tabs-vertical-arrow-down
+title: "Tabs — In vertical orientation, ArrowDown moves to the next tab"
+type: positive
+description: 'When configured with orientation="vertical", ArrowDown takes the place of
+  ArrowRight for moving between tabs.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-tabs--vertical-bare&viewMode=story"
+
+expected_result: "After ArrowDown from Overview, Pricing is selected."
+
+steps:
+  - locate: tab "Overview"
+  - focus: tab "Overview"
+  - keyboard: "ArrowDown"
+  - verify: tab "Pricing" attribute "aria-selected" is "true"

--- a/usecases/textbox/textbox-invalid.uc.yaml
+++ b/usecases/textbox/textbox-invalid.uc.yaml
@@ -1,0 +1,18 @@
+id: textbox-invalid
+title: "Textbox — Invalid state surfaces aria-invalid and an error message"
+type: positive
+description: 'When invalid is set, the textbox advertises aria-invalid="true" and
+  references its error message via aria-errormessage. The error renders as a
+  live region (role="alert").'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-textbox--invalid&viewMode=story"
+
+expected_result: 'aria-invalid is "true" and the error message is announced via role="alert".'
+
+steps:
+  - locate: field "Email"
+  - verify: field "Email" attribute "aria-invalid" is "true"
+  - verify: alert "Enter a valid email address."

--- a/usecases/textbox/textbox-multiline.uc.yaml
+++ b/usecases/textbox/textbox-multiline.uc.yaml
@@ -1,0 +1,16 @@
+id: textbox-multiline
+title: 'Textbox — Multi-line textbox advertises aria-multiline="true"'
+type: positive
+description: 'When configured with multiline, the textbox renders a textarea and exposes
+  aria-multiline="true".'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-textbox--multi-line&viewMode=story"
+
+expected_result: 'aria-multiline is "true".'
+
+steps:
+  - locate: field "Bio"
+  - verify: field "Bio" attribute "aria-multiline" is "true"

--- a/usecases/textbox/textbox-readonly.uc.yaml
+++ b/usecases/textbox/textbox-readonly.uc.yaml
@@ -1,0 +1,17 @@
+id: textbox-readonly
+title: 'Textbox — ReadOnly textbox advertises aria-readonly="true"'
+type: positive
+description: 'A read-only textbox exposes aria-readonly="true" and retains its value as
+  the displayed text.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-textbox--read-only&viewMode=story"
+
+expected_result: 'aria-readonly is "true" and the value is "ACCT-12345".'
+
+steps:
+  - locate: field "Account ID"
+  - verify: field "Account ID" attribute "aria-readonly" is "true"
+  - verify: field "Account ID" has_value "ACCT-12345"

--- a/usecases/textbox/textbox-required.uc.yaml
+++ b/usecases/textbox/textbox-required.uc.yaml
@@ -1,0 +1,16 @@
+id: textbox-required
+title: 'Textbox — Required textbox advertises aria-required="true"'
+type: positive
+description: 'A required textbox exposes aria-required="true" so AT can convey that input
+  is mandatory.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-textbox--required&viewMode=story"
+
+expected_result: 'aria-required is "true".'
+
+steps:
+  - locate: field "Username"
+  - verify: field "Username" attribute "aria-required" is "true"

--- a/usecases/textbox/textbox-typing.uc.yaml
+++ b/usecases/textbox/textbox-typing.uc.yaml
@@ -1,0 +1,18 @@
+id: textbox-typing
+title: "Textbox — Typing into the textbox updates its value"
+type: positive
+description: "A user can locate, focus, and type into the textbox; the new value is
+  reflected back via the input value."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-textbox--single-line&viewMode=story"
+
+expected_result: 'The textbox value is "Jane".'
+
+steps:
+  - locate: field "Full name"
+  - focus: field "Full name"
+  - enter: field "Full name" value "Jane"
+  - verify: field "Full name" has_value "Jane"

--- a/usecases/toolbar/toolbar-arrow-left-wraps.uc.yaml
+++ b/usecases/toolbar/toolbar-arrow-left-wraps.uc.yaml
@@ -1,0 +1,18 @@
+id: toolbar-arrow-left-wraps
+title: "Toolbar — ArrowLeft wraps from the first item to the last"
+type: positive
+description: "When focus is on the first toolbar item, ArrowLeft wraps focus to the last
+  item."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-toolbar--default&viewMode=story"
+
+expected_result: 'Focus moves from "Bold" to "Link".'
+
+steps:
+  - locate: button "Bold"
+  - focus: button "Bold"
+  - keyboard: "ArrowLeft"
+  - verify: focus button "Link"

--- a/usecases/toolbar/toolbar-arrow-right.uc.yaml
+++ b/usecases/toolbar/toolbar-arrow-right.uc.yaml
@@ -1,0 +1,18 @@
+id: toolbar-arrow-right
+title: "Toolbar — ArrowRight moves focus to the next toolbar item"
+type: positive
+description: "When focus is on a toolbar button, ArrowRight moves focus to the next button
+  in the toolbar."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-toolbar--default&viewMode=story"
+
+expected_result: 'Focus moves from "Bold" to "Italic".'
+
+steps:
+  - locate: button "Bold"
+  - focus: button "Bold"
+  - keyboard: "ArrowRight"
+  - verify: focus button "Italic"

--- a/usecases/toolbar/toolbar-home-end.uc.yaml
+++ b/usecases/toolbar/toolbar-home-end.uc.yaml
@@ -1,0 +1,19 @@
+id: toolbar-home-end
+title: "Toolbar — Home and End jump to first and last items"
+type: positive
+description: "Home moves focus to the first toolbar item; End moves focus to the last."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-toolbar--default&viewMode=story"
+
+expected_result: 'End focuses "Link"; Home returns focus to "Bold".'
+
+steps:
+  - locate: button "Bold"
+  - focus: button "Bold"
+  - keyboard: "End"
+  - verify: focus button "Link"
+  - keyboard: "Home"
+  - verify: focus button "Bold"

--- a/usecases/toolbar/toolbar-role-and-orientation.uc.yaml
+++ b/usecases/toolbar/toolbar-role-and-orientation.uc.yaml
@@ -1,0 +1,16 @@
+id: toolbar-role-and-orientation
+title: 'Toolbar — Container is exposed via role="toolbar" with horizontal orientation'
+type: positive
+description: 'The Toolbar container advertises role="toolbar" with the configured label
+  and aria-orientation="horizontal".'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-toolbar--default&viewMode=story"
+
+expected_result: 'A toolbar named "Formatting" is present with horizontal orientation.'
+
+steps:
+  - locate: role "toolbar" name "Formatting"
+  - verify: role "toolbar" name "Formatting" attribute "aria-orientation" is "horizontal"

--- a/usecases/tooltip/tooltip-aria-describedby.uc.yaml
+++ b/usecases/tooltip/tooltip-aria-describedby.uc.yaml
@@ -1,0 +1,18 @@
+id: tooltip-aria-describedby
+title: "Tooltip — Trigger references the tooltip via aria-describedby when visible"
+type: positive
+description: "While the tooltip is visible, the trigger advertises aria-describedby
+  pointing at the tooltip element so AT can announce the description."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-tooltip--top&viewMode=story"
+
+expected_result: 'After focus, the trigger has aria-describedby="tooltip-text".'
+
+steps:
+  - locate: button "Hover or focus me"
+  - focus: button "Hover or focus me"
+  - wait_for: text "Tooltip on top"
+  - verify: button "Hover or focus me" attribute "aria-describedby" is "tooltip-text"

--- a/usecases/tooltip/tooltip-escape-hides.uc.yaml
+++ b/usecases/tooltip/tooltip-escape-hides.uc.yaml
@@ -1,0 +1,21 @@
+id: tooltip-escape-hides
+title: "Tooltip — Escape hides the visible tooltip"
+type: positive
+description: "Per the APG, pressing Escape while a tooltip is visible dismisses it without
+  moving focus."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-tooltip--top&viewMode=story"
+
+expected_result: "After Escape the tooltip is no longer present and focus stays on the
+  trigger."
+
+steps:
+  - locate: button "Hover or focus me"
+  - focus: button "Hover or focus me"
+  - wait_for: text "Tooltip on top"
+  - keyboard: "Escape"
+  - verify: hidden text "Tooltip on top"
+  - verify: focus button "Hover or focus me"

--- a/usecases/tooltip/tooltip-on-focus.uc.yaml
+++ b/usecases/tooltip/tooltip-on-focus.uc.yaml
@@ -1,0 +1,19 @@
+id: tooltip-on-focus
+title: "Tooltip — Focusing the trigger reveals the tooltip"
+type: positive
+description: 'Per the APG, a tooltip is shown when its trigger receives keyboard focus,
+  not just on hover. The tooltip is exposed via role="tooltip".'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-tooltip--top&viewMode=story"
+
+expected_result: 'A tooltip with text "Tooltip on top" is visible after the trigger receives
+  focus.'
+
+steps:
+  - locate: button "Hover or focus me"
+  - focus: button "Hover or focus me"
+  - wait_for: text "Tooltip on top"
+  - verify: visible text "Tooltip on top"

--- a/usecases/tree-grid/tree-grid-arrow-down.uc.yaml
+++ b/usecases/tree-grid/tree-grid-arrow-down.uc.yaml
@@ -1,0 +1,18 @@
+id: tree-grid-arrow-down
+title: "TreeGrid — ArrowDown moves focus to the next visible row in the same column"
+type: positive
+description: "Per the APG, ArrowDown moves focus to the cell immediately below the current
+  cell."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-treegrid--default-bare&viewMode=story"
+
+expected_result: 'Focus moves from the "src" cell to the "index.js" cell.'
+
+steps:
+  - locate: role "gridcell" name "src"
+  - focus: role "gridcell" name "src"
+  - keyboard: "ArrowDown"
+  - verify: focus role "gridcell" name "index.js"

--- a/usecases/tree-grid/tree-grid-arrow-left-collapses.uc.yaml
+++ b/usecases/tree-grid/tree-grid-arrow-left-collapses.uc.yaml
@@ -1,0 +1,21 @@
+id: tree-grid-arrow-left-collapses
+title: "TreeGrid — ArrowLeft on the first cell of an expanded row collapses it"
+type: positive
+description: "Per the APG, when focus is on the first cell of an expanded row, ArrowLeft
+  collapses that row."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-treegrid--default-bare&viewMode=story"
+
+expected_result: 'After ArrowLeft on the "src" cell, the "index.js" row is no longer
+  visible.'
+
+steps:
+  - locate: role "gridcell" name "src"
+  - focus: role "gridcell" name "src"
+  - locate: role "gridcell" name "index.js"
+  - focus: role "gridcell" name "src"
+  - keyboard: "ArrowLeft"
+  - verify: hidden role "gridcell" name "index.js"

--- a/usecases/tree-grid/tree-grid-arrow-right-expands.uc.yaml
+++ b/usecases/tree-grid/tree-grid-arrow-right-expands.uc.yaml
@@ -1,0 +1,21 @@
+id: tree-grid-arrow-right-expands
+title: "TreeGrid — ArrowRight on the first cell of a collapsed row expands it"
+type: positive
+description: "Per the APG, when focus is on the first cell of a row that has children and
+  is collapsed, ArrowRight expands that row."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-treegrid--default-bare&viewMode=story"
+
+expected_result: 'After collapsing src and pressing ArrowRight on it, the "index.js" cell is
+  visible again.'
+
+steps:
+  - locate: role "gridcell" name "src"
+  - focus: role "gridcell" name "src"
+  - keyboard: "ArrowLeft"
+  - verify: hidden role "gridcell" name "index.js"
+  - keyboard: "ArrowRight"
+  - verify: visible role "gridcell" name "index.js"

--- a/usecases/tree-grid/tree-grid-home-end-row.uc.yaml
+++ b/usecases/tree-grid/tree-grid-home-end-row.uc.yaml
@@ -1,0 +1,21 @@
+id: tree-grid-home-end-row
+title: "TreeGrid — Home and End move focus within the current row"
+type: positive
+description: "Home moves focus to the first cell of the row; End moves focus to the last
+  cell."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-treegrid--default-bare&viewMode=story"
+
+expected_result: "End focuses the Modified cell of the src row; Home returns focus to the
+  src cell."
+
+steps:
+  - locate: role "gridcell" name "src"
+  - focus: role "gridcell" name "src"
+  - keyboard: "End"
+  - verify: focus role "gridcell" name "2026-04-10"
+  - keyboard: "Home"
+  - verify: focus role "gridcell" name "src"

--- a/usecases/tree-grid/tree-grid-role.uc.yaml
+++ b/usecases/tree-grid/tree-grid-role.uc.yaml
@@ -1,0 +1,15 @@
+id: tree-grid-role
+title: 'TreeGrid — Container is exposed via role="treegrid" with a name'
+type: positive
+description: 'The TreeGrid container advertises role="treegrid" with the configured label
+  as its accessible name.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-treegrid--default-bare&viewMode=story"
+
+expected_result: 'A treegrid named "Project files" is present.'
+
+steps:
+  - locate: role "treegrid" name "Project files"

--- a/usecases/tree-view/tree-view-aria-level.uc.yaml
+++ b/usecases/tree-view/tree-view-aria-level.uc.yaml
@@ -1,0 +1,19 @@
+id: tree-view-aria-level
+title: "TreeView — Treeitems advertise aria-level matching their depth"
+type: positive
+description: 'Top-level treeitems report aria-level="1"; children one nesting deeper
+  report aria-level="2".'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-treeview--default-bare&viewMode=story"
+
+expected_result: 'src reports aria-level="1"; the visible "components" treeitem reports
+  aria-level="2".'
+
+steps:
+  - locate: role "treeitem" name "src"
+  - verify: role "treeitem" name "src" attribute "aria-level" is "1"
+  - locate: role "treeitem" name "components"
+  - verify: role "treeitem" name "components" attribute "aria-level" is "2"

--- a/usecases/tree-view/tree-view-arrow-down.uc.yaml
+++ b/usecases/tree-view/tree-view-arrow-down.uc.yaml
@@ -1,0 +1,18 @@
+id: tree-view-arrow-down
+title: "TreeView — ArrowDown moves focus to the next visible treeitem"
+type: positive
+description: "Per the APG, ArrowDown moves focus to the next visible treeitem regardless
+  of nesting depth."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-treeview--default-bare&viewMode=story"
+
+expected_result: 'Focus moves from "src" to "components".'
+
+steps:
+  - locate: role "treeitem" name "src"
+  - focus: role "treeitem" name "src"
+  - keyboard: "ArrowDown"
+  - verify: focus role "treeitem" name "components"

--- a/usecases/tree-view/tree-view-arrow-left-collapses.uc.yaml
+++ b/usecases/tree-view/tree-view-arrow-left-collapses.uc.yaml
@@ -1,0 +1,19 @@
+id: tree-view-arrow-left-collapses
+title: "TreeView — ArrowLeft collapses an expanded parent treeitem"
+type: positive
+description: 'When focus is on an open parent treeitem, ArrowLeft collapses it
+  (aria-expanded becomes "false") without moving focus.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-treeview--default-bare&viewMode=story"
+
+expected_result: 'After ArrowLeft on the expanded "src" item, aria-expanded becomes "false".'
+
+steps:
+  - locate: role "treeitem" name "src"
+  - focus: role "treeitem" name "src"
+  - verify: role "treeitem" name "src" attribute "aria-expanded" is "true"
+  - keyboard: "ArrowLeft"
+  - verify: role "treeitem" name "src" attribute "aria-expanded" is "false"

--- a/usecases/tree-view/tree-view-arrow-left-on-leaf-moves-to-parent.uc.yaml
+++ b/usecases/tree-view/tree-view-arrow-left-on-leaf-moves-to-parent.uc.yaml
@@ -1,0 +1,18 @@
+id: tree-view-arrow-left-on-leaf-moves-to-parent
+title: "TreeView — ArrowLeft on a leaf treeitem focuses its parent"
+type: positive
+description: "When focus is on a leaf (or a closed parent) at depth > 1, ArrowLeft moves
+  focus to the parent treeitem."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-treeview--default-bare&viewMode=story"
+
+expected_result: 'Focus moves from "components" (level 2) to "src" (level 1).'
+
+steps:
+  - locate: role "treeitem" name "components"
+  - focus: role "treeitem" name "components"
+  - keyboard: "ArrowLeft"
+  - verify: focus role "treeitem" name "src"

--- a/usecases/tree-view/tree-view-arrow-right-expands.uc.yaml
+++ b/usecases/tree-view/tree-view-arrow-right-expands.uc.yaml
@@ -1,0 +1,20 @@
+id: tree-view-arrow-right-expands
+title: "TreeView — ArrowRight expands a collapsed parent treeitem"
+type: positive
+description: 'When focus is on a collapsed parent treeitem, ArrowRight expands it
+  (aria-expanded becomes "true") without moving focus.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-treeview--default-bare&viewMode=story"
+
+expected_result: 'After ArrowRight on the collapsed "components" item, aria-expanded becomes
+  "true".'
+
+steps:
+  - locate: role "treeitem" name "components"
+  - focus: role "treeitem" name "components"
+  - verify: role "treeitem" name "components" attribute "aria-expanded" is "false"
+  - keyboard: "ArrowRight"
+  - verify: role "treeitem" name "components" attribute "aria-expanded" is "true"

--- a/usecases/tree-view/tree-view-arrow-right-open-moves-to-child.uc.yaml
+++ b/usecases/tree-view/tree-view-arrow-right-open-moves-to-child.uc.yaml
@@ -1,0 +1,19 @@
+id: tree-view-arrow-right-open-moves-to-child
+title: "TreeView — ArrowRight on an open parent moves focus to its first child"
+type: positive
+description: "When focus is on a parent treeitem that is already expanded, ArrowRight
+  moves focus to the first child treeitem."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-treeview--default-bare&viewMode=story"
+
+expected_result: 'Focus moves from "src" to "components" (its first child).'
+
+steps:
+  - locate: role "treeitem" name "src"
+  - focus: role "treeitem" name "src"
+  - verify: role "treeitem" name "src" attribute "aria-expanded" is "true"
+  - keyboard: "ArrowRight"
+  - verify: focus role "treeitem" name "components"

--- a/usecases/tree-view/tree-view-enter-selects.uc.yaml
+++ b/usecases/tree-view/tree-view-enter-selects.uc.yaml
@@ -1,0 +1,18 @@
+id: tree-view-enter-selects
+title: "TreeView — Enter selects the focused treeitem"
+type: positive
+description: 'Pressing Enter on a focused treeitem sets aria-selected="true" on it (and
+  toggles expansion when the item has children).'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-treeview--default-bare&viewMode=story"
+
+expected_result: 'README.md reports aria-selected="true" after Enter.'
+
+steps:
+  - locate: role "treeitem" name "README.md"
+  - focus: role "treeitem" name "README.md"
+  - keyboard: "Enter"
+  - verify: role "treeitem" name "README.md" attribute "aria-selected" is "true"

--- a/usecases/tree-view/tree-view-home-end.uc.yaml
+++ b/usecases/tree-view/tree-view-home-end.uc.yaml
@@ -1,0 +1,20 @@
+id: tree-view-home-end
+title: "TreeView — Home and End move focus to first and last visible treeitems"
+type: positive
+description: "Home moves focus to the first visible treeitem; End moves focus to the
+  last."
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-treeview--default-bare&viewMode=story"
+
+expected_result: 'End focuses "README.md"; Home returns focus to "src".'
+
+steps:
+  - locate: role "treeitem" name "src"
+  - focus: role "treeitem" name "src"
+  - keyboard: "End"
+  - verify: focus role "treeitem" name "README.md"
+  - keyboard: "Home"
+  - verify: focus role "treeitem" name "src"

--- a/usecases/tree-view/tree-view-role-and-name.uc.yaml
+++ b/usecases/tree-view/tree-view-role-and-name.uc.yaml
@@ -1,0 +1,15 @@
+id: tree-view-role-and-name
+title: 'TreeView — Outer list is exposed via role="tree" with a name'
+type: positive
+description: 'The TreeView container advertises role="tree" with the configured label as
+  its accessible name.'
+
+preconditions:
+  - "Storybook is running on http://localhost:6006"
+
+start_location: "http://localhost:6006/iframe.html?id=components-treeview--default-bare&viewMode=story"
+
+expected_result: 'A tree named "Project files" is present.'
+
+steps:
+  - locate: role "tree" name "Project files"


### PR DESCRIPTION
## Summary

Closes #66.

- Adds 174 use cases across 31 components in `usecases/`, written in the DSL of [`@afixt/usecase-runner`](https://www.npmjs.com/package/@afixt/usecase-runner). Each `.uc.yaml` documents one discrete user interaction (click, keyboard navigation, ARIA assertion) targeting the component's Storybook story.
- Adds 34 play-free `*Bare` sibling stories across 17 components so the cases load with the initial render state instead of post-`play()` residue. Original stories keep their `play` blocks for the Storybook Interactions panel.
- Fixes two real focus-management bugs in `AlertDialog` and `ModalDialog` that the use cases surfaced:
  1. Focus restoration on close was racing with the focus trap — the trap yanked focus back to the dialog before `onClose` unmounted it. Guarded with a `closingRef`.
  2. Tab inside a dialog with no further focusable elements after it landed focus on `document.body` (no focus event fires) — added explicit Tab/Shift+Tab cycling in keydown.
  Shared logic extracted to `components/_internal/dialog-focus.ts`.
- Adds an additive `initiallyRotating?: boolean` prop to `Carousel` (defaults to `true`) so the bare story can render with auto-rotation paused for deterministic test runs.

## Test plan

- [x] `npx --yes @afixt/usecase-runner validate usecases/` — all 174 cases parse cleanly
- [x] `npx --yes @afixt/usecase-runner run usecases/ --browser chromium` against built Storybook — **174/174 pass**
- [x] `npm test` — 295/295 unit + a11y contract tests pass; no regressions
- [x] `npm run check:all` (pre-push hook) — lint, typecheck, dupe scan, security, build all green
- [ ] CI passes on this branch