### PR TITLE
chore: drop Node 20, bump eslint-plugin-jsdoc to 63 (supersedes #106)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22]
+        node: [22, 24]
     steps:
       - uses: actions/checkout@v6
 
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build-storybook

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "eslint": "9.39.4",
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-import-x": "4.16.2",
-        "eslint-plugin-jsdoc": "62.9.0",
+        "eslint-plugin-jsdoc": "^63.0.0",
         "eslint-plugin-jsx-a11y": "6.10.2",
         "eslint-plugin-no-secrets": "2.3.3",
         "eslint-plugin-promise": "7.3.0",
@@ -75,7 +75,7 @@
         "vite": "^5.4.21"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.13.0"
       },
       "peerDependencies": {
         "react": ">=18.0.0",
@@ -9974,10 +9974,11 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "62.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.9.0.tgz",
-      "integrity": "sha512-PY7/X4jrVgoIDncUmITlUqK546Ltmx/Pd4Hdsu4CvSjryQZJI2mEV4vrdMufyTetMiZ5taNSqvK//BTgVUlNkA==",
+      "version": "63.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.0.0.tgz",
+      "integrity": "sha512-eDHuVGyZydr4BKgjXouU7bsn5qaqUlObXBSWRJk3vXcQgXVFnrwWIqpP7uBhRX9NQpk6NIIFyRc6F6omZNi/8g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@es-joy/jsdoccomment": "~0.86.0",
         "@es-joy/resolve.exports": "1.2.0",
@@ -9990,12 +9991,12 @@
         "html-entities": "^2.6.0",
         "object-deep-merge": "^2.0.0",
         "parse-imports-exports": "^0.2.4",
-        "semver": "^7.7.4",
+        "semver": "^7.8.0",
         "spdx-expression-parse": "^4.0.0",
         "to-valid-identifier": "^1.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^22.13.0 || >=24"
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
@@ -10043,10 +10044,11 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "prepare": "husky"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "peerDependencies": {
     "react": ">=18.0.0",
@@ -125,7 +125,7 @@
     "eslint": "9.39.4",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-import-x": "4.16.2",
-    "eslint-plugin-jsdoc": "62.9.0",
+    "eslint-plugin-jsdoc": "^63.0.0",
     "eslint-plugin-jsx-a11y": "6.10.2",
     "eslint-plugin-no-secrets": "2.3.3",
     "eslint-plugin-promise": "7.3.0",


### PR DESCRIPTION
## Drop Node 20 support + bump eslint-plugin-jsdoc to 63

Node 20 "Iron" reached **end-of-life on 2026-04-30**. This raises the project's Node floor and folds in the previously-blocked `eslint-plugin-jsdoc@63.0.0` bump (Dependabot #106), whose only breaking change was dropping Node 20.

### Changes
- `package.json` → `engines.node`: `>=20.0.0` → **`>=22.13.0`**
- `.github/workflows/ci.yml` → test matrix `[20, 22]` → **`[22, 24]`**; `publish-storybook` setup-node `20` → **`22`**
- `eslint-plugin-jsdoc` `62.9.0` → **`^63.0.0`** (+ lockfile)

### Verification
- `npm install` clean on Node 24
- `npm run lint` → **0 errors** (23 pre-existing warnings, unrelated)
- `npm test` → **295/295 passing**, 32 suites

### Impact
- **Consumers:** raised runtime floor to Node ≥ 22.13 — a deliberate, consumer-facing change. Best released as a minor/major version bump with a CHANGELOG note.
- **Security/a11y:** no runtime change; jsdoc is a dev-only lint plugin.
- **Forward-looking:** a modern Node baseline is also a prerequisite for the eventual ESLint 10 upgrade (#114), which is currently blocked separately on `eslint-plugin-jsx-a11y` / `eslint-plugin-react` peer support.

Supersedes #106.
