### PR TITLE
docs: note org-level NPM_TOKEN for @afixt scoped packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,3 +129,11 @@ GitHub Actions workflow at `.github/workflows/ci.yml`:
 - Components with hardcoded user-facing strings (aria-labels, button text)
   expose an optional `labels` prop so consumers can provide translations.
   English defaults are always provided.
+
+## @afixt scoped packages & NPM_TOKEN
+
+If this project installs any `@afixt/*` scoped packages, npm authentication is handled by an **organization-level GitHub Actions secret** named `NPM_TOKEN`. The org-level secret is **always** the one to use.
+
+- Installing `@afixt/*` scoped packages should **not** return `404`. A `404` here is an authentication/token problem, not a missing package.
+- If you do hit a `404`, remove any **repo-level** `NPM_TOKEN` secret — a repo-level token is likely stale and conflicts with the org-level secret.
+- Do not override `NPM_TOKEN` per repository; always rely on the org-level secret.


### PR DESCRIPTION
Adds a CLAUDE.md note: @afixt/* scoped packages authenticate via the **org-level** GitHub `NPM_TOKEN` secret (always the one to use). Installs should not 404; if they do, remove any conflicting repo-level `NPM_TOKEN`. CLAUDE.md was appended.